### PR TITLE
fix #11: flattened keys in array are now correctly parsed

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -137,7 +137,6 @@ module.exports = function (str, depth) {
     var obj = {};
 
     // Iterate over the keys and setup the new object
-
     for (var key in tempObj) {
         if (tempObj.hasOwnProperty(key)) {
             var newObj = internals.parseKeys(key, tempObj[key], depth);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,11 @@ exports.merge = function (target, source) {
     if (Array.isArray(source)) {
         for (var i = 0, il = source.length; i < il; ++i) {
             if (source[i] !== undefined) {
-                obj[i] = source[i];
+                if (typeof obj[i] === 'object') {
+                    obj[i] = exports.merge(obj[i], source[i]);
+                } else {
+                    obj[i] = source[i];
+                }
             }
         }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -138,6 +138,7 @@ describe('#parse', function () {
         expect(Qs.parse('foo[bad]=baz&foo[]=bar')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar' } });
         expect(Qs.parse('foo[]=bar&foo[bad]=baz')).to.deep.equal({ foo: { '0': 'bar', bad: 'baz' } });
         expect(Qs.parse('foo[bad]=baz&foo[]=bar&foo[]=foo')).to.deep.equal({ foo: { bad: 'baz', '0': 'bar', '1': 'foo' } });
+        expect(Qs.parse('foo[0][a]=a&foo[0][b]=b&foo[1][a]=aa&foo[1][b]=bb')).to.deep.equal({foo: [ {a: 'a', b: 'b'}, {a: 'aa', b: 'bb'} ]});
         done();
     });
 


### PR DESCRIPTION
`Qs` can now parse:  

`anArray[0][a]=a&anArray[0][b]=b&anArray[1][a]=aa&anArray[1][b]=bb`  
to

``` js
var data = {
  anArray: [
    { a: 'a', b: 'b' },
    { a: 'aa', b: 'bb' }
  ]
};
```
