### PR TITLE
ignore non-string delimiters

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -15,7 +15,7 @@ var internals = {
 
 internals.parseValues = function (str, delimiter) {
 
-    delimiter = typeof delimiter === 'undefined' ? internals.delimiter : delimiter;
+    delimiter = typeof delimiter === 'string' ? delimiter : internals.delimiter;
 
     var obj = {};
     var parts = str.split(delimiter, internals.parametersLimit);

--- a/test/parse.js
+++ b/test/parse.js
@@ -252,4 +252,10 @@ describe('#parse', function () {
         expect(Qs.parse('a=b;c=d', ';')).to.deep.equal({ a: 'b', c: 'd' });
         done();
     });
+
+    it('should not use non-string objects as delimiters', function (done) {
+
+        expect(Qs.parse('a=b&c=d', {})).to.deep.equal({ a: 'b', c: 'd' });
+        done();
+    });
 });


### PR DESCRIPTION
Prior to this, anything that wasn't `undefined` would be an acceptable delimiter. This doesn't really make sense, so this fixes that. In the event that a non-string delimiter is provided, it is simply ignored.
