### PR TITLE
Enable using a RegExp as delimiter

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -133,7 +133,7 @@ module.exports = function (str, options) {
     }
 
     options = options || {};
-    options.delimiter = typeof options.delimiter === 'string' ? options.delimiter : internals.delimiter;
+    options.delimiter = typeof options.delimiter === 'string' || Utils.isRegExp(options.delimiter) ? options.delimiter : internals.delimiter;
     options.depth = typeof options.depth === 'number' ? options.depth : internals.depth;
     options.arrayLimit = typeof options.arrayLimit === 'number' ? options.arrayLimit : internals.arrayLimit;
     options.parameterLimit = typeof options.parameterLimit === 'number' ? options.parameterLimit : internals.parameterLimit;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,3 +131,7 @@ exports.compact = function (obj) {
 
     return compacted;
 };
+
+exports.isRegExp = function (obj) {
+    return Object.prototype.toString.call(obj) === '[object RegExp]';
+};

--- a/test/parse.js
+++ b/test/parse.js
@@ -247,13 +247,19 @@ describe('#parse', function () {
         done();
     });
 
-    it('parses a string with an alternative delimiter', function (done) {
+    it('parses a string with an alternative string delimiter', function (done) {
 
         expect(Qs.parse('a=b;c=d', { delimiter: ';' })).to.deep.equal({ a: 'b', c: 'd' });
         done();
     });
 
-    it('does not use non-string objects as delimiters', function (done) {
+    it('parses a string with an alternative RegExp delimiter', function (done) {
+
+        expect(Qs.parse('a=b; c=d', { delimiter: /[;,] */ })).to.deep.equal({ a: 'b', c: 'd' });
+        done();
+    });
+
+    it('does not use non-splittable objects as delimiters', function (done) {
 
         expect(Qs.parse('a=b&c=d', { delimiter: true })).to.deep.equal({ a: 'b', c: 'd' });
         done();


### PR DESCRIPTION
This fixes a regression that was introduced in #16 which prevents
anything but a string from being used as a delimiter. But the whole
point of #12 was to allow users to specify a RegExp to use in
`queryString.split(delimiter)`.
