### PR TITLE
Don't use Buffer global if it's not present

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,5 +1,7 @@
 // Load modules
 
+var Utils = require('./utils');
+
 
 // Declare internals
 
@@ -10,7 +12,7 @@ var internals = {
 
 internals.stringify = function (obj, prefix) {
 
-    if (Buffer.isBuffer(obj)) {
+    if (Utils.isBuffer(obj)) {
         obj = obj.toString();
     }
     else if (obj instanceof Date) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,9 @@
 
 // Declare internals
 
-var internals = {};
+var internals = {
+    returnFalse: function () { return false; }
+};
 
 
 exports.arrayToObject = function (source) {
@@ -28,7 +30,7 @@ exports.clone = function (source) {
         return source;
     }
 
-    if (Buffer.isBuffer(source)) {
+    if (exports.isBuffer(source)) {
         return source.toString();
     }
 
@@ -135,3 +137,9 @@ exports.compact = function (obj) {
 exports.isRegExp = function (obj) {
     return Object.prototype.toString.call(obj) === '[object RegExp]';
 };
+
+if (typeof Buffer !== 'undefined') {
+    exports.isBuffer = Buffer.isBuffer;
+} else {
+    exports.isBuffer = internals.returnFalse;
+}


### PR DESCRIPTION
This change makes it easy to use qs in a browser environment (e.g. via Browserify) without requiring the `Buffer` module.

Fixes #25
