### PR TITLE
make qs usable for browser loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib');
+module.exports = require('./lib/');


### PR DESCRIPTION
lib is a folder, it is impossible to judge whether lib is folder or file with browser loader
