### PR TITLE
Change package "main" to the dist-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/hapijs/qs.git"
   },
-  "main": "lib/index.js",
+  "main": "dist/qs.js",
   "keywords": [
     "querystring",
     "qs"


### PR DESCRIPTION
Removes the need for babel (or similar) when require'ing qs for use in the browser.