### PR TITLE
[Docs] Add usage instructions for browsers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The **qs** module was originally created and maintained by [TJ Holowaychuk](http
 
 ## Usage
 
+For Node: 
 ```javascript
 var qs = require('qs');
 var assert = require('assert');
@@ -19,6 +20,17 @@ assert.deepEqual(obj, { a: 'c' });
 
 var str = qs.stringify(obj);
 assert.equal(str, 'a=c');
+```
+For Browsers: 
+```html
+<script type="text/javascript" href="/path/to/qs/dist/qs.js"></script>
+<script type="text/javascript">
+  var obj = Qs.parse('a=c');
+  console.log(obj); // { a: 'c' }
+
+  var str = Qs.stringify(obj);
+  console.log(obj); // 'a=c'
+</script>
 ```
 
 ### Parsing Objects


### PR DESCRIPTION
Add usage instructions for browsers as the README only has usage for node environment and it is difficult to figure out how to use it in browsers (without using something like browserify/webpack). 

I myself had to go to https://github.com/ljharb/qs/blob/master/dist/qs.js and figure out myself how to do that. 