### PR TITLE
Feature/encoder decoder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,12 +4,12 @@
 	"extends": "@ljharb",
 
 	"rules": {
-		"complexity": [2, 19],
+		"complexity": [2, 22],
 		"consistent-return": [1],
 		"id-length": [2, { "min": 1, "max": 25, "properties": "never" }],
 		"indent": [2, 4],
 		"max-params": [2, 9],
-		"max-statements": [2, 33],
+		"max-statements": [2, 36],
 		"no-extra-parens": [1],
 		"no-continue": [1],
 		"no-magic-numbers": 0,

--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ var unencoded = qs.stringify({ a: { b: 'c' } }, { encode: false });
 assert.equal(unencoded, 'a[b]=c');
 ```
 
+This encoding can also be replaced by a custom encoding method set as `encoder` option:
+
+```javascript
+var encoded = qs.stringify({ a: { b: 'c' } }, { encoder: function (str) {
+  // Passed in values `a`, `b`, `c`
+  return // Return encoded string
+}})
+```
+
+_(Note: the `encoder` option does not apply if `encode` is `false`)_
+
 Examples beyond this point will be shown as though the output is not URI encoded for clarity. Please note that the return values in these cases *will* be URI encoded during real usage.
 
 When arrays are stringified, by default they are given explicit indices:

--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ var encoded = qs.stringify({ a: { b: 'c' } }, { encoder: function (str) {
 
 _(Note: the `encoder` option does not apply if `encode` is `false`)_
 
+Analogue to the `encoder` there is a `decoder` option for `parse` to override decoding of properties and values:
+
+```javascript
+var decoded = qs.parse('x=z', { decoder: function (str) {
+  // Passed in values `x`, `z`
+  return // Return decoded string
+}})
+```
+
 Examples beyond this point will be shown as though the output is not URI encoded for clarity. Please note that the return values in these cases *will* be URI encoded during real usage.
 
 When arrays are stringified, by default they are given explicit indices:

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,7 +10,8 @@ var defaults = {
     strictNullHandling: false,
     plainObjects: false,
     allowPrototypes: false,
-    allowDots: false
+    allowDots: false,
+    decoder: Utils.decode
 };
 
 var parseValues = function parseValues(str, options) {
@@ -22,14 +23,14 @@ var parseValues = function parseValues(str, options) {
         var pos = part.indexOf(']=') === -1 ? part.indexOf('=') : part.indexOf(']=') + 1;
 
         if (pos === -1) {
-            obj[Utils.decode(part)] = '';
+            obj[options.decoder(part)] = '';
 
             if (options.strictNullHandling) {
-                obj[Utils.decode(part)] = null;
+                obj[options.decoder(part)] = null;
             }
         } else {
-            var key = Utils.decode(part.slice(0, pos));
-            var val = Utils.decode(part.slice(pos + 1));
+            var key = options.decoder(part.slice(0, pos));
+            var val = options.decoder(part.slice(pos + 1));
 
             if (Object.prototype.hasOwnProperty.call(obj, key)) {
                 obj[key] = [].concat(obj[key]).concat(val);
@@ -130,10 +131,16 @@ var parseKeys = function parseKeys(givenKey, val, options) {
 
 module.exports = function (str, opts) {
     var options = opts || {};
+
+    if (options.decoder !== null && options.decoder !== undefined && typeof options.decoder !== 'function') {
+        throw new TypeError('Decoder has to be a function.');
+    }
+
     options.delimiter = typeof options.delimiter === 'string' || Utils.isRegExp(options.delimiter) ? options.delimiter : defaults.delimiter;
     options.depth = typeof options.depth === 'number' ? options.depth : defaults.depth;
     options.arrayLimit = typeof options.arrayLimit === 'number' ? options.arrayLimit : defaults.arrayLimit;
     options.parseArrays = options.parseArrays !== false;
+    options.decoder = typeof options.decoder === 'function' ? options.decoder : defaults.decoder;
     options.allowDots = typeof options.allowDots === 'boolean' ? options.allowDots : defaults.allowDots;
     options.plainObjects = typeof options.plainObjects === 'boolean' ? options.plainObjects : defaults.plainObjects;
     options.allowPrototypes = typeof options.allowPrototypes === 'boolean' ? options.allowPrototypes : defaults.allowPrototypes;

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -18,10 +18,11 @@ var defaults = {
     delimiter: '&',
     strictNullHandling: false,
     skipNulls: false,
-    encode: true
+    encode: true,
+    encoder: Utils.encode
 };
 
-var stringify = function stringify(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encode, filter, sort, allowDots) {
+var stringify = function stringify(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots) {
     var obj = object;
     if (typeof filter === 'function') {
         obj = filter(prefix, obj);
@@ -31,15 +32,15 @@ var stringify = function stringify(object, prefix, generateArrayPrefix, strictNu
         obj = obj.toISOString();
     } else if (obj === null) {
         if (strictNullHandling) {
-            return encode ? Utils.encode(prefix) : prefix;
+            return encoder ? encoder(prefix) : prefix;
         }
 
         obj = '';
     }
 
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') {
-        if (encode) {
-            return [Utils.encode(prefix) + '=' + Utils.encode(obj)];
+        if (encoder) {
+            return [encoder(prefix) + '=' + encoder(obj)];
         }
         return [prefix + '=' + obj];
     }
@@ -66,9 +67,9 @@ var stringify = function stringify(object, prefix, generateArrayPrefix, strictNu
         }
 
         if (Array.isArray(obj)) {
-            values = values.concat(stringify(obj[key], generateArrayPrefix(prefix, key), generateArrayPrefix, strictNullHandling, skipNulls, encode, filter, sort, allowDots));
+            values = values.concat(stringify(obj[key], generateArrayPrefix(prefix, key), generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots));
         } else {
-            values = values.concat(stringify(obj[key], prefix + (allowDots ? '.' + key : '[' + key + ']'), generateArrayPrefix, strictNullHandling, skipNulls, encode, filter, sort, allowDots));
+            values = values.concat(stringify(obj[key], prefix + (allowDots ? '.' + key : '[' + key + ']'), generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots));
         }
     }
 
@@ -82,10 +83,16 @@ module.exports = function (object, opts) {
     var strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
     var skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : defaults.skipNulls;
     var encode = typeof options.encode === 'boolean' ? options.encode : defaults.encode;
+    var encoder = encode ? (typeof options.encoder === 'function' ? options.encoder : defaults.encoder) : null;
     var sort = typeof options.sort === 'function' ? options.sort : null;
     var allowDots = typeof options.allowDots === 'undefined' ? false : options.allowDots;
     var objKeys;
     var filter;
+
+    if (options.encoder !== null && options.encoder !== undefined && typeof options.encoder !== 'function') {
+        throw new TypeError('Encoder has to be a function.');
+    }
+
     if (typeof options.filter === 'function') {
         filter = options.filter;
         obj = filter('', obj);
@@ -125,7 +132,7 @@ module.exports = function (object, opts) {
             continue;
         }
 
-        keys = keys.concat(stringify(obj[key], key, generateArrayPrefix, strictNullHandling, skipNulls, encode, filter, sort, allowDots));
+        keys = keys.concat(stringify(obj[key], key, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots));
     }
 
     return keys.join(delimiter);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint": "^2.9.0",
     "@ljharb/eslint-config": "^4.0.0",
     "parallelshell": "^2.0.0",
+    "iconv-lite": "^0.4.13",
     "evalmd": "^0.0.17"
   },
   "scripts": {

--- a/test/parse.js
+++ b/test/parse.js
@@ -2,6 +2,7 @@
 
 var test = require('tape');
 var qs = require('../');
+var iconv = require('iconv-lite');
 
 test('parse()', function (t) {
     t.test('parses a simple string', function (st) {
@@ -391,6 +392,32 @@ test('parse()', function (t) {
         expectedArray.a['0'] = 'b';
         expectedArray.a.c = 'd';
         st.deepEqual(qs.parse('a[]=b&a[c]=d', { plainObjects: true }), expectedArray);
+        st.end();
+    });
+
+    t.test('can parse with custom encoding', function (st) {
+        st.deepEqual(qs.parse('%8c%a7=%91%e5%8d%e3%95%7b', {
+            decoder: function (str) {
+                var reg = /\%([0-9A-F]{2})/ig;
+                var result = [];
+                var parts;
+                var last = 0;
+                while (parts = reg.exec(str)) {
+                    result.push(parseInt(parts[1], 16));
+                    last = parts.index + parts[0].length;
+                }
+                return iconv.decode(new Buffer(result), 'shift_jis').toString();
+            }
+        }), { 県: '大阪府' });
+        st.end();
+    });
+
+    t.test('throws error with wrong decoder', function (st) {
+        st.throws(function () {
+            qs.parse({}, {
+                decoder: 'string'
+            });
+        }, new TypeError('Decoder has to be a function.'));
         st.end();
     });
 });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -2,6 +2,7 @@
 
 var test = require('tape');
 var qs = require('../');
+var iconv = require('iconv-lite');
 
 test('stringify()', function (t) {
     t.test('stringifies a querystring object', function (st) {
@@ -259,6 +260,32 @@ test('stringify()', function (t) {
         var sort = function (a, b) { return a.localeCompare(b); };
         st.equal(qs.stringify({ a: 'a', z: { zj: {zjb: 'zjb', zja: 'zja'}, zi: {zib: 'zib', zia: 'zia'} }, b: 'b' }, { sort: sort, encode: false }), 'a=a&b=b&z[zi][zia]=zia&z[zi][zib]=zib&z[zj][zja]=zja&z[zj][zjb]=zjb');
         st.equal(qs.stringify({ a: 'a', z: { zj: {zjb: 'zjb', zja: 'zja'}, zi: {zib: 'zib', zia: 'zia'} }, b: 'b' }, { sort: null, encode: false }), 'a=a&z[zj][zjb]=zjb&z[zj][zja]=zja&z[zi][zib]=zib&z[zi][zia]=zia&b=b');
+        st.end();
+    });
+
+    t.test('can stringify with custom encoding', function (st) {
+        st.equal(qs.stringify({ 県: '大阪府', '': ''}, {
+            encoder: function (str) {
+                if (str.length === 0) {
+                    return '';
+                }
+                var buf = iconv.encode(str, 'shiftjis');
+                var result = [];
+                for (var i=0; i < buf.length; ++i) {
+                    result.push(buf.readUInt8(i).toString(16));
+                }
+                return '%' + result.join('%');
+            }
+        }), '%8c%a7=%91%e5%8d%e3%95%7b&=');
+        st.end();
+    });
+
+    t.test('throws error with wrong encoder', function (st) {
+        st.throws(function () {
+            qs.stringify({}, {
+                encoder: 'string'
+            });
+        }, new TypeError('Encoder has to be a function.'));
         st.end();
     });
 });


### PR DESCRIPTION
This PR adds a `decoder` and `encoder` option for querystrings. These option are important when dealing with servers that process data in a form other than `utf8`. Namely when trying to send a request to Servers that use `shift_jis` as method this is an important feature.

Note: I choose to add an option instead of re-using the `encode` option to only require semver-minor. Also I bumped the limit for the linting because I couldn't figure out how to push this change more elegantly.