### PR TITLE
Added documentation on how to use qs-iconv with qs

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,24 @@ To completely skip rendering keys with `null` values, use the `skipNulls` flag:
 var nullsSkipped = qs.stringify({ a: 'b', c: null}, { skipNulls: true });
 assert.equal(nullsSkipped, 'a=b');
 ```
+
+### Dealing with special character sets
+
+By default the encoding and decoding of characters is done in `utf-8`. If you 
+wish to encode querystrings to a different character set (i.e.
+[Shift JIS](https://en.wikipedia.org/wiki/Shift_JIS)) you can use the
+[`qs-iconv`](https://github.com/martinheidegger/qs-iconv) library:
+
+```javascript
+var encoder = require('qs-iconv/encoder')('shift_jis');
+var shiftJISEncoded = qs.stringify({ a: 'こんにちは！' }, { encoder: encoder });
+assert.equal(shiftJISEncoded, 'a=%82%B1%82%F1%82%C9%82%BF%82%CD%81I');
+```
+
+This also works for decoding of query strings:
+
+```javascript
+var decoder = require('qs-iconv/decoder')('shift_jis');
+var obj = qs.parse('a=%82%B1%82%F1%82%C9%82%BF%82%CD%81I', { decoder: decoder });
+assert.deepEqual(obj, { a: 'こんにちは！' });
+```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@ljharb/eslint-config": "^4.0.0",
     "parallelshell": "^2.0.0",
     "iconv-lite": "^0.4.13",
+    "qs-iconv": "^1.0.1",
     "evalmd": "^0.0.17"
   },
   "scripts": {


### PR DESCRIPTION
I recently publish [qs-iconv](https://github.com/martinheidegger/qs-iconv) that should make it very easy to transform querystrings to a different character encoding. This PR adds the documentation on how to use it to `qs` as well since this is likely a reoccurring issue.