### PR TITLE
add a link to cdnjs in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ var str = qs.stringify(obj);
 assert.equal(str, 'a=c');
 ```
 
+For client-side (browser) use, the library can be loaded from a CDN. See [cdnjs](https://cdnjs.com/libraries/qs) for the URL to include in your `<script>` tag.
+
 ### Parsing Objects
 
 [](#preventEval)


### PR DESCRIPTION
Now that this library is available from cdnjs for client-side/browser use, document it in the README file.