### PR TITLE
Second argument to encoder callback

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,6 +1,10 @@
 'use strict';
 
 var utils = require('./utils');
+var encodeParts = {
+    key: 'key',
+    val: 'val'
+};
 
 var arrayPrefixGenerators = {
     brackets: function brackets(prefix) {
@@ -35,7 +39,7 @@ var stringify = function stringify(object, prefix, generateArrayPrefix, strictNu
         obj = serializeDate(obj);
     } else if (obj === null) {
         if (strictNullHandling) {
-            return encoder ? encoder(prefix) : prefix;
+            return encoder ? encoder(prefix, encodeParts.key) : prefix;
         }
 
         obj = '';
@@ -43,7 +47,7 @@ var stringify = function stringify(object, prefix, generateArrayPrefix, strictNu
 
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
         if (encoder) {
-            return [encoder(prefix) + '=' + encoder(obj)];
+            return [encoder(prefix, encodeParts.key) + '=' + encoder(obj, encodeParts.val)];
         }
         return [prefix + '=' + String(obj)];
     }


### PR DESCRIPTION
With Second argument to encoder callback that indicate witch part of object send to encoder (key or value),
it possible to perform a different action depend on current part.

for example i someone want to decode only the right part (url params value, only what in the right side of `=` sign)