### PR TITLE
remember index to reuse in else statement; avoid recalling indexOf

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -24,7 +24,9 @@ var parseValues = function parseQueryStringValues(str, options) {
 
     for (var i = 0; i < parts.length; ++i) {
         var part = parts[i];
-        var pos = part.indexOf(']=') === -1 ? part.indexOf('=') : part.indexOf(']=') + 1;
+
+        var bracketEqualsPos = part.indexOf(']=');
+        var pos = bracketEqualsPos === -1 ? part.indexOf('=') : bracketEqualsPos + 1;
 
         var key, val;
         if (pos === -1) {


### PR DESCRIPTION
Avoid running the same `indexOf(']=')` operation twice by storing the result and reusing in the else statement.