### PR TITLE
fix link to contributing document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-Please view our [hapijs contributing guide](https://github.com/hapijs/hapi/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
The referenced document was moved into `.github` directory. This changes the link to point to its new location.