### PR TITLE
speedup array work by using push instead of concat

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -34,12 +34,7 @@ var parseValues = function parseValues(str, options) {
         }
 
         if (has.call(obj, key)) {
-            var cur = obj[key];
-            if (Array.isArray(cur)) {
-                cur.push(val);
-            } else {
-                obj[key] = [cur, val];
-            }
+            obj[key] = utils.combine(obj[key], val);
         } else {
             obj[key] = val;
         }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -32,8 +32,14 @@ var parseValues = function parseValues(str, options) {
             key = options.decoder(part.slice(0, pos));
             val = options.decoder(part.slice(pos + 1));
         }
+
         if (has.call(obj, key)) {
-            obj[key] = [].concat(obj[key]).concat(val);
+            var cur = obj[key];
+            if (Array.isArray(cur)) {
+                cur.push(val);
+            } else {
+                obj[key] = [cur, val];
+            }
         } else {
             obj[key] = val;
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,5 +196,6 @@ exports.combine = function combine(a, b) {
         return b;
     }
 
+    // neither are arrays, so, create a new array with both
     return [a, b];
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -178,3 +178,23 @@ exports.isBuffer = function (obj) {
 
     return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
 };
+
+exports.combine = function combine(a, b) {
+    // we always use both of these, so, let's calculate them now
+    var firstIsArray  = Array.isArray(a);
+    var secondIsArray = Array.isArray(b);
+
+    // mutate `a` to append `b` and then return it
+    if (firstIsArray) {
+        secondIsArray ? a.push.apply(a, b) : a.push(b);
+        return a;
+    }
+
+    // mutate `b` to prepend `a` and then return it
+    if (secondIsArray) {
+        b.unshift(a);
+        return b;
+    }
+
+    return [a, b];
+};


### PR DESCRIPTION
Current implementation creates "throw away" (intermediary) arrays with two `concat()` calls on an empty initial new array.

It could instead be `obj[key] = [].concat(obj[key], val);` which puts both values in the same call to `concat()`. This is only marginally faster.

The fastest way is using `push()` when it's an array and creating the new array with the values otherwise. When testing with 10 million iterations this way is an order of magnitude faster than the two above methods. It also avoids creating a lot of "throw away" arrays.

Travic CI failure is due to new linting seeing unnecessary escapes. I fixed those in a new PR #184.
