### PR TITLE
Benchmark combo

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ bower.json
 component.json
 .npmignore
 .travis.yml
+benchmark/

--- a/benchmark/.eslintrc
+++ b/benchmark/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "no-console": 0,
+    },
+}

--- a/benchmark/arraying.js
+++ b/benchmark/arraying.js
@@ -1,0 +1,142 @@
+'use strict';
+
+require('console.table');
+
+var comma = require('comma-number');
+var Benchmark = require('benchmark');
+
+Benchmark.options.initCount = 100;
+Benchmark.options.minSamples = 100;
+
+// useful when altering tests, causes thing to run quickly
+// Benchmark.options.initCount = 1
+// Benchmark.options.minSamples = 1
+// Benchmark.options.minTime = -1
+// Benchmark.options.maxTime = -1
+
+var singles = function singles(fn) {
+    return function () {
+        return fn('1', '2');
+    };
+};
+
+var arrayThenSingle = function arrayThenSingle(fn) {
+    return function () {
+        return fn([
+            '1', '11', '111'
+        ], '2');
+    };
+};
+
+var singleThenArray = function singleThenArray(fn) {
+    return function () {
+        return fn('1', [
+            '2', '22', '222'
+        ]);
+    };
+};
+
+var arrays = function arrays(fn) {
+    return function () {
+        return fn([
+            '1', '11', '111'
+        ], [
+            '2', '22', '222'
+        ]);
+    };
+};
+
+var methods = [
+    function original(a, b) {
+        return [].concat(a, b);
+    },
+
+    function consolidated(a, b) {
+        return [].concat(a, b);
+    },
+
+    function awkward(a, b) {
+        return Array.prototype.concat(a, b);
+    },
+
+    // this isn't able to handle the second arg being an array.
+    function halfway(a, b) {
+        if (Array.isArray(a)) {
+            a.push(b);
+            return a;
+        } else {
+            return [a, b];
+        }
+    },
+
+    function mutating(a, b) {
+    // we always use both of these, so, let's calculate them now
+        var firstIsArray = Array.isArray(a);
+        var secondIsArray = Array.isArray(b);
+
+        // mutate `a` to append `b` and then return it
+        if (firstIsArray) {
+            if (secondIsArray) {
+                a.push.apply(a, b);
+            } else {
+                a.push(b);
+            }
+            return a;
+        }
+
+        // mutate `b` to prepend `a` and then return it
+        if (secondIsArray) {
+            b.unshift(a);
+            return b;
+        }
+
+        // neither are arrays, so, create a new array with both
+        return [a, b];
+    }
+];
+
+methods[0].style = '[].concat(a).concat(b)';
+methods[1].style = '[].concat(a, b)';
+methods[2].style = 'Array.prototype.concat(a, b)';
+methods[3].style = 'Array.isArray halfway';
+methods[4].style = 'Array.isArray both';
+
+var suite = new Benchmark.Suite();
+var results = [];
+
+methods.forEach(function (method, index) {
+    results.push([method.style]);
+
+    suite.add(method.style + ' with 2 non-arrays', singles(method));
+    suite.add(method.style + ' with an array then a non-array', arrayThenSingle(method));
+
+    if (index !== 3) {
+        suite.add(method.style + ' with a non-array then an array', singleThenArray(method));
+        suite.add(method.style + ' with 2 arrays', arrays(method));
+    }
+});
+
+var row = 0;
+
+suite.on('cycle', function (event) {
+    var its = event.target;
+
+    console.log('completed', its.name);
+
+    results[row].push(comma(its.hz.toFixed(0)) + ' (+-' + its.stats.rme.toFixed(2) + '%)');
+
+    if (results[row].length === 5 || (row === 3 && results[row].length === 3)) {
+        row += 1;
+    }
+});
+
+suite.on('complete', function () {
+    console.log();
+    console.table([
+        'Name', '" / "', '[] / "', '" / []', '[] / []'
+    ], results);
+});
+
+suite.run({
+    async: false
+});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -212,7 +212,28 @@ var isBuffer = function isBuffer(obj) {
 };
 
 var combine = function combine(a, b) {
-    return [].concat(a, b);
+    // we always use both of these, so, let's calculate them now
+    var firstIsArray = Array.isArray(a);
+    var secondIsArray = Array.isArray(b);
+
+    // mutate `a` to append `b` and then return it
+    if (firstIsArray) {
+        if (secondIsArray) {
+            a.push.apply(a, b);
+        } else {
+            a.push(b);
+        }
+        return a;
+    }
+
+    // mutate `b` to prepend `a` and then return it
+    if (secondIsArray) {
+        b.unshift(a);
+        return b;
+    }
+
+    // neither are arrays, so, create a new array with both
+    return [a, b];
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "dependencies": {},
     "devDependencies": {
         "@ljharb/eslint-config": "^13.0.0",
+        "benchmark": "^2.1.4",
         "browserify": "^16.2.2",
+        "comma-number": "^2.0.0",
+        "console.table": "^0.10.0",
         "covert": "^1.1.0",
         "editorconfig-tools": "^0.1.1",
         "eslint": "^5.6.0",


### PR DESCRIPTION
See #185 and #187 

This PR applies the benchmarking stuff first. Then moves the combo stuff to the utils function with the original implementation. Then replaces it with the new implementation.

Run benchmark with `node benchmark/arraying.js`.

There's a variety of ways to setup how to run benchmarking scripts as you add more. Could use npm scripts entry per each benchmark. Or, make an index file in there which accepts a subcommand for which one to run so there's only one npm run script. I leave those decisions up to you.

Adding the new implementation is last so you can peel it off from the PR if you'd like. 