### PR TITLE
add empty object and array values example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ Empty strings and null values will omit the value, but the equals sign (=) remai
 assert.equal(qs.stringify({ a: '' }), 'a=');
 ```
 
+Key with no values (such as an empty object or array) will return nothing:
+
+```javascript
+assert.equal(qs.stringify({ a: [] }), '');
+assert.equal(qs.stringify({ a: {} }), '');
+assert.equal(qs.stringify({ a: [{}] }), '');
+assert.equal(qs.stringify({ a: { b: []} }), '');
+assert.equal(qs.stringify({ a: { b: {}} }), '');
+```
+
 Properties that are set to `undefined` will be omitted entirely:
 
 ```javascript


### PR DESCRIPTION
#164 has non-issue tag.

As my original expectation is `assert.equal(qs.stringify({ a: {} }), 'a');`

but actually is  `assert.equal(qs.stringify({ a: {} }), '');`

so I think it should be documented.