### PR TITLE
Encoder prefix boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ assert.equal(unencoded, 'a[b]=c');
 This encoding can also be replaced by a custom encoding method set as `encoder` option:
 
 ```javascript
-var encoded = qs.stringify({ a: { b: 'c' } }, { encoder: function (str) {
+var encoded = qs.stringify({ a: { b: 'c' } }, { encoder: function (str, prefix) {
   // Passed in values `a`, `b`, `c`
+  // prefix is true for 'a' and 'b' values
   return // Return encoded string
 }})
 ```
@@ -400,7 +401,7 @@ assert.equal(nullsSkipped, 'a=b');
 
 ### Dealing with special character sets
 
-By default the encoding and decoding of characters is done in `utf-8`. If you 
+By default the encoding and decoding of characters is done in `utf-8`. If you
 wish to encode querystrings to a different character set (i.e.
 [Shift JIS](https://en.wikipedia.org/wiki/Shift_JIS)) you can use the
 [`qs-iconv`](https://github.com/martinheidegger/qs-iconv) library:

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ assert.equal(unencoded, 'a[b]=c');
 This encoding can also be replaced by a custom encoding method set as `encoder` option:
 
 ```javascript
-var encoded = qs.stringify({ a: { b: 'c' } }, { encoder: function (str, prefix) {
+var encoded = qs.stringify({ a: { b: 'c' } }, { encoder: function (str, isPrefix) {
   // Passed in values `a`, `b`, `c`
-  // prefix is true for 'a' and 'b' values
+  // isPrefix is true for 'a' and 'b' values, false for 'c' value
   return // Return encoded string
 }})
 ```

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -48,7 +48,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
         obj = serializeDate(obj);
     } else if (obj === null) {
         if (strictNullHandling) {
-            return encoder ? encoder(prefix) : prefix;
+            return encoder ? encoder(prefix, true) : prefix;
         }
 
         obj = '';
@@ -56,7 +56,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
 
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
         if (encoder) {
-            return [formatter(encoder(prefix)) + '=' + formatter(encoder(obj))];
+            return [formatter(encoder(prefix, true)) + '=' + formatter(encoder(obj, false))];
         }
         return [formatter(prefix) + '=' + formatter(String(obj))];
     }

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -438,8 +438,8 @@ test('stringify()', function (t) {
     t.test('prefix boolean for encoder', function (st) {
         var prefixKeys = [];
         st.equal(qs.stringify({ a: 'b', c: ['d', 'e'], f: [['g'], ['h']] }, {
-            encoder: function (str, prefix) {
-                if (prefix) {
+            encoder: function (str, isPrefix) {
+                if (isPrefix) {
                     prefixKeys.push(str);
                 }
                 return str;

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -435,6 +435,20 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('prefix boolean for encoder', function (st) {
+        var prefixKeys = [];
+        st.equal(qs.stringify({ a: 'b', c: ['d', 'e'], f: [['g'], ['h']] }, {
+            encoder: function (str, prefix) {
+                if (prefix) {
+                    prefixKeys.push(str);
+                }
+                return str;
+            }
+        }), 'a=b&c[0]=d&c[1]=e&f[0][0]=g&f[1][0]=h');
+        st.same(prefixKeys, ['a', 'c[0]', 'c[1]', 'f[0][0]', 'f[1][0]']);
+        st.end();
+    });
+
     t.test('can stringify with custom encoding', function (st) {
         st.equal(qs.stringify({ 県: '大阪府', '': '' }, {
             encoder: function (str) {


### PR DESCRIPTION
Reason: We want to only encode our values to keep the url "pretty" help the url be shorter. 

For example: 
`{q: "test", categories: [["movie"],["Crime"]], actors: ["a", 'b-c', 'd & e', 'f=g'], writers: ['d'] }` 
to be `q=test&categories[0][0]=movie&categories[1][0]=Crime&actors[0]=a&actors[1]=b-c&actors[2]=d%20%26%20e&actors[3]=f%3Dg&writers[0]=d`
fully encoded: would escape `categories[0][0]`

welcome any feedback on improvements. This is a feature for searchkit, an open source ui framework for elasticsearch. 