### PR TITLE
Handle stringifying empty objects with addQueryPrefix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,12 +4,12 @@
     "extends": "@ljharb",
 
     "rules": {
-        "complexity": [2, 27],
+        "complexity": [2, 28],
         "consistent-return": 1,
         "id-length": [2, { "min": 1, "max": 25, "properties": "never" }],
         "indent": [2, 4],
         "max-params": [2, 12],
-        "max-statements": [2, 44],
+        "max-statements": [2, 45],
         "no-continue": 1,
         "no-magic-numbers": 0,
         "no-restricted-syntax": [2, "BreakStatement", "DebuggerStatement", "ForInStatement", "LabeledStatement", "WithStatement"],

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -203,7 +203,8 @@ module.exports = function (object, opts) {
         ));
     }
 
+    var joined = keys.join(delimiter);
     var prefix = options.addQueryPrefix === true ? '?' : '';
 
-    return prefix + keys.join(delimiter);
+    return joined.length > 0 ? prefix + joined : '';
 };

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -23,6 +23,11 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('with query prefix, outputs blank string given an empty object', function (st) {
+        st.equal(qs.stringify({}, { addQueryPrefix: true }), '');
+        st.end();
+    });
+
     t.test('stringifies a nested object', function (st) {
         st.equal(qs.stringify({ a: { b: 'c' } }), 'a%5Bb%5D=c');
         st.equal(qs.stringify({ a: { b: { c: { d: 'e' } } } }), 'a%5Bb%5D%5Bc%5D%5Bd%5D=e');


### PR DESCRIPTION
Submitting PR as agreed, this should fix the issue described in #213:

Stringifying an empty object would produce a string such as '?'. With
this fix, we output an empty string instead.

Sorry about increasing complexity and max-statements in `.eslintrc`,
I didn't see a quick way to reduce complexity.

Thanks for this great library 👍 