### PR TITLE
Use precise dist for Node.js 0.6 runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: precise
 os:
  - linux
 node_js:


### PR DESCRIPTION
My PR #224 is failing on Node.js 0.6 because Travis CI recently swapped out the distro from Precise to Trusty, and the Node.js 0.6 source is failing to compile. There may be another choice, but this is what I've been doing for my modules, at least.