### PR TITLE
Feature> emptyValue options for parse & stringify

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -15,6 +15,7 @@ var defaults = {
     decoder: utils.decode,
     delimiter: '&',
     depth: 5,
+    emptyValue: '',
     ignoreQueryPrefix: false,
     interpretNumericEntities: false,
     parameterLimit: 1000,
@@ -82,7 +83,7 @@ var parseValues = function parseQueryStringValues(str, options) {
         var key, val;
         if (pos === -1) {
             key = options.decoder(part, defaults.decoder, charset, 'key');
-            val = options.strictNullHandling ? null : '';
+            val = options.strictNullHandling ? null : options.emptyValue;
         } else {
             key = options.decoder(part.slice(0, pos), defaults.decoder, charset, 'key');
             val = utils.maybeMap(
@@ -212,6 +213,11 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
     if (typeof opts.charset !== 'undefined' && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
         throw new TypeError('The charset option must be either utf-8, iso-8859-1, or undefined');
     }
+
+    if (opts.strictNullHandling === true && has.call(opts, 'emptyValue')) {
+        throw new TypeError('Passing true for strictNullHandling will cause emptyValue to be ignored');
+    }
+
     var charset = typeof opts.charset === 'undefined' ? defaults.charset : opts.charset;
 
     return {
@@ -225,6 +231,7 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
         // eslint-disable-next-line no-implicit-coercion, no-extra-parens
         depth: (typeof opts.depth === 'number' || opts.depth === false) ? +opts.depth : defaults.depth,
+        emptyValue: has.call(opts, 'emptyValue') ? defaults.emptyValue : opts.emptyValue,
         ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
         interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
         parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -20,8 +20,7 @@ var defaults = {
     interpretNumericEntities: false,
     parameterLimit: 1000,
     parseArrays: true,
-    plainObjects: false,
-    strictNullHandling: false
+    plainObjects: false
 };
 
 var interpretNumericEntities = function (str) {
@@ -83,7 +82,7 @@ var parseValues = function parseQueryStringValues(str, options) {
         var key, val;
         if (pos === -1) {
             key = options.decoder(part, defaults.decoder, charset, 'key');
-            val = options.strictNullHandling ? null : options.emptyValue;
+            val = options.emptyValue;
         } else {
             key = options.decoder(part.slice(0, pos), defaults.decoder, charset, 'key');
             val = utils.maybeMap(
@@ -214,9 +213,7 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         throw new TypeError('The charset option must be either utf-8, iso-8859-1, or undefined');
     }
 
-    if (opts.strictNullHandling === true && has.call(opts, 'emptyValue')) {
-        throw new TypeError('Passing true for strictNullHandling will cause emptyValue to be ignored');
-    }
+    var defaultEmptyValue = opts.strictNullHandling === true ? null : defaults.emptyValue
 
     var charset = typeof opts.charset === 'undefined' ? defaults.charset : opts.charset;
 
@@ -231,13 +228,12 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
         // eslint-disable-next-line no-implicit-coercion, no-extra-parens
         depth: (typeof opts.depth === 'number' || opts.depth === false) ? +opts.depth : defaults.depth,
-        emptyValue: has.call(opts, 'emptyValue') ? defaults.emptyValue : opts.emptyValue,
+        emptyValue: has.call(opts, 'emptyValue') ? opts.emptyValue : defaultEmptyValue,
         ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
         interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
         parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,
         parseArrays: opts.parseArrays !== false,
         plainObjects: typeof opts.plainObjects === 'boolean' ? opts.plainObjects : defaults.plainObjects,
-        strictNullHandling: typeof opts.strictNullHandling === 'boolean' ? opts.strictNullHandling : defaults.strictNullHandling
     };
 };
 

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -32,6 +32,7 @@ var defaults = {
     charset: 'utf-8',
     charsetSentinel: false,
     delimiter: '&',
+    emptyValue: null,
     encode: true,
     encoder: utils.encode,
     encodeValuesOnly: false,
@@ -59,6 +60,7 @@ var stringify = function stringify(
     prefix,
     generateArrayPrefix,
     strictNullHandling,
+    emptyValue,
     skipNulls,
     encoder,
     filter,
@@ -83,8 +85,8 @@ var stringify = function stringify(
         }).join(',');
     }
 
-    if (obj === null) {
-        if (strictNullHandling) {
+    if (obj === null || obj === emptyValue) {
+        if (strictNullHandling || (obj === emptyValue && emptyValue !== null)) {
             return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, 'key') : prefix;
         }
 
@@ -130,6 +132,7 @@ var stringify = function stringify(
             keyPrefix,
             generateArrayPrefix,
             strictNullHandling,
+            emptyValue,
             skipNulls,
             encoder,
             filter,
@@ -179,6 +182,7 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
         charset: charset,
         charsetSentinel: typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
         delimiter: typeof opts.delimiter === 'undefined' ? defaults.delimiter : opts.delimiter,
+        emptyValue: has.call(options, 'emptyValue') ? options.emptyValue : defaults.emptyValue,
         encode: typeof opts.encode === 'boolean' ? opts.encode : defaults.encode,
         encoder: typeof opts.encoder === 'function' ? opts.encoder : defaults.encoder,
         encodeValuesOnly: typeof opts.encodeValuesOnly === 'boolean' ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
@@ -242,6 +246,7 @@ module.exports = function (object, opts) {
             key,
             generateArrayPrefix,
             options.strictNullHandling,
+            options.emptyValue,
             options.skipNulls,
             options.encode ? options.encoder : null,
             options.filter,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -85,11 +85,11 @@ var stringify = function stringify(
         }).join(',');
     }
 
-    if (obj === null || obj === emptyValue) {
-        if (strictNullHandling || (obj === emptyValue && emptyValue !== null)) {
-            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, 'key') : prefix;
-        }
+    if ((strictNullHandling && obj === null) || (emptyValue !== null && obj === emptyValue)) {
+        return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, 'key') : prefix;
+    }
 
+    if (obj === null) {
         obj = '';
     }
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -324,6 +324,7 @@ test('stringify()', function (t) {
 
     t.test('stringifies an empty value', function (st) {
         st.equal(qs.stringify({ a: '' }), 'a=');
+        st.equal(qs.stringify({ a: null }), 'a=');
         st.equal(qs.stringify({ a: null }, { strictNullHandling: true }), 'a');
 
         st.equal(qs.stringify({ a: '', b: '' }), 'a=&b=');
@@ -333,6 +334,10 @@ test('stringify()', function (t) {
         st.equal(qs.stringify({ a: { b: null } }, { strictNullHandling: true }), 'a%5Bb%5D');
         st.equal(qs.stringify({ a: { b: null } }, { strictNullHandling: false }), 'a%5Bb%5D=');
 
+        st.equal(qs.stringify({ a: true }, { emptyValue: true }), 'a');
+
+        st.equal(qs.stringify({ a: null, b: true }, { emptyValue: true }), 'a=&b');
+        st.equal(qs.stringify({ a: null, b: true }, { strictNullHandling: true, emptyValue: true }), 'a&b');
         st.end();
     });
 


### PR DESCRIPTION
Addresses #223.

Behavior:
* When parsing and encountering empty values, replaces them with
opt.emptyValue (default to '')
* When stringifying and encountering value === opt.emptyValue, outputs a key
without a value