### PR TITLE
Rename formats.default to formats.defaultFormat

### DIFF
--- a/lib/formats.js
+++ b/lib/formats.js
@@ -4,7 +4,7 @@ var replace = String.prototype.replace;
 var percentTwenties = /%20/g;
 
 module.exports = {
-    'default': 'RFC3986',
+    defaultFormat: 'RFC3986',
     formatters: {
         RFC1738: function (value) {
             return replace.call(value, percentTwenties, '+');

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -139,7 +139,7 @@ module.exports = function (object, opts) {
     var serializeDate = typeof options.serializeDate === 'function' ? options.serializeDate : defaults.serializeDate;
     var encodeValuesOnly = typeof options.encodeValuesOnly === 'boolean' ? options.encodeValuesOnly : defaults.encodeValuesOnly;
     if (typeof options.format === 'undefined') {
-        options.format = formats['default'];
+        options.format = formats.defaultFormat;
     } else if (!Object.prototype.hasOwnProperty.call(formats.formatters, options.format)) {
         throw new TypeError('Unknown format option provided.');
     }


### PR DESCRIPTION
Having an attribute named 'default' confuses rollup when packaging.

See https://github.com/rollup/rollup/issues/1135 for instance.