### PR TITLE
Added ability to set no limits on arrays length (qs.parse arrayLimit option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,11 @@ assert.deepEqual(withMaxIndex, { a: { '100': 'b' } });
 This limit can be overridden by passing an `arrayLimit` option:
 
 ```javascript
-var withArrayLimit = qs.parse('a[1]=b', { arrayLimit: 0 });
+var withArrayLimit = qs.parse('a[1]=b', { arrayLimit: 50 });
 assert.deepEqual(withArrayLimit, { a: { '1': 'b' } });
 ```
+
+If `arrayLimit` option is set to 0, then no limits in arrays length are considered.
 
 To disable array parsing entirely, set `parseArrays` to `false`.
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -65,7 +65,7 @@ var parseObject = function (chain, val, options) {
                 && root !== cleanRoot
                 && String(index) === cleanRoot
                 && index >= 0
-                && (options.parseArrays && index <= options.arrayLimit)
+                && (options.parseArrays && (options.arrayLimit === 0 || index <= options.arrayLimit))
             ) {
                 obj = [];
                 obj[index] = leaf;


### PR DESCRIPTION
Previous behaviour:

- Behaviour of arrayLimit = 0 option is the same of parseArrays = false
- The only way to parse arrays of any length is to set arrayLimit to a large value

New behaviour:

- By setting arrayLimit = 0, no length limits are considered