### PR TITLE
Quote the sub-property for compatibility with closure-compiler

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -168,7 +168,7 @@ var encode = function encode(str) {
 };
 
 var compact = function compact(value) {
-    var queue = [{ obj: { o: value }, prop: 'o' }];
+    var queue = [{ obj: { 'o': value }, prop: 'o' }]; // eslint-disable-line quote-props
     var refs = [];
 
     for (var i = 0; i < queue.length; ++i) {


### PR DESCRIPTION
2ed6ea4560cfb36eb6581b75bf148aa29b456210 broke compatibility with closure-compiler in ADVANCED mode.
Quoting this one key is all that is required to fix it.