### PR TITLE
stringify: Avoid arr = arr.concat(...), push to the existing instance

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -15,6 +15,12 @@ var arrayPrefixGenerators = {
     }
 };
 
+var isArray = Array.isArray;
+var push = Array.prototype.push;
+var pushToArray = function (arr, valueOrArray) {
+    push.apply(arr, isArray(valueOrArray) ? valueOrArray : [valueOrArray]);
+};
+
 var toISO = Date.prototype.toISOString;
 
 var defaults = {
@@ -95,7 +101,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
         }
 
         if (Array.isArray(obj)) {
-            values = values.concat(stringify(
+            pushToArray(values, stringify(
                 obj[key],
                 generateArrayPrefix(prefix, key),
                 generateArrayPrefix,
@@ -111,7 +117,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
                 charset
             ));
         } else {
-            values = values.concat(stringify(
+            pushToArray(values, stringify(
                 obj[key],
                 prefix + (allowDots ? '.' + key : '[' + key + ']'),
                 generateArrayPrefix,
@@ -202,8 +208,7 @@ module.exports = function (object, opts) {
         if (skipNulls && obj[key] === null) {
             continue;
         }
-
-        keys = keys.concat(stringify(
+        pushToArray(keys, stringify(
             obj[key],
             key,
             generateArrayPrefix,


### PR DESCRIPTION
Currently `qs.stringify` will create a new array whenever a new parameter is added. This fixes it by pushing to the existing one instead.

Very unscientific benchmark:

```
time node -e "const qs = require('./');for (let i = 0 ; i < 1000000 ; i += 1)qs.stringify({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11, l: 12, m: 13, n: 14, o: 15, p: 16, q: 17, r: 18, s: 19, t: 20, u: 21, v: 22, x: 23, y: 24, z: 25});"
```

Before:

```
real	0m11.247s
user	0m11.260s
sys	0m0.093s
```

After:

```
real	0m6.291s
user	0m6.305s
sys	0m0.052s
```
