### PR TITLE
ES Modules & CJS builds

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,12 @@
+{
+    "presets": [
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "node": true
+                }
+            }
+        ]
+    ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,9 @@
 {
     "root": true,
+    "parserOptions": {
+        "sourceType": "module",
+        "ecmaVersion": 6
+    },
 
     "extends": "@ljharb",
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 
 # build output
 dist/*
+lib/cjs/
 
 # Only apps should have lockfiles
 yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 bower.json
 component.json
 .npmignore
+.babelrc
 .travis.yml
+rollup.config.js

--- a/dist/qs.js
+++ b/dist/qs.js
@@ -1,638 +1,691 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Qs = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
-'use strict';
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.Qs = {})));
+}(this, (function (exports) { 'use strict';
 
-var replace = String.prototype.replace;
-var percentTwenties = /%20/g;
+    const replace = String.prototype.replace;
+    const percentTwenties = /%20/g;
 
-module.exports = {
-    'default': 'RFC3986',
-    formatters: {
+    const formatters = {
         RFC1738: function (value) {
             return replace.call(value, percentTwenties, '+');
         },
         RFC3986: function (value) {
             return value;
         }
-    },
-    RFC1738: 'RFC1738',
-    RFC3986: 'RFC3986'
-};
+    };
 
-},{}],2:[function(require,module,exports){
-'use strict';
+    const RFC1738 = 'RFC1738';
+    const RFC3986 = 'RFC3986';
 
-var stringify = require('./stringify');
-var parse = require('./parse');
-var formats = require('./formats');
+    var formats = /*#__PURE__*/Object.freeze({
+        formatters: formatters,
+        RFC1738: RFC1738,
+        RFC3986: RFC3986,
+        default: RFC3986
+    });
 
-module.exports = {
-    formats: formats,
-    parse: parse,
-    stringify: stringify
-};
+    const has = Object.prototype.hasOwnProperty;
 
-},{"./formats":1,"./parse":3,"./stringify":4}],3:[function(require,module,exports){
-'use strict';
-
-var utils = require('./utils');
-
-var has = Object.prototype.hasOwnProperty;
-
-var defaults = {
-    allowDots: false,
-    allowPrototypes: false,
-    arrayLimit: 20,
-    decoder: utils.decode,
-    delimiter: '&',
-    depth: 5,
-    parameterLimit: 1000,
-    plainObjects: false,
-    strictNullHandling: false
-};
-
-var parseValues = function parseQueryStringValues(str, options) {
-    var obj = {};
-    var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
-    var limit = options.parameterLimit === Infinity ? undefined : options.parameterLimit;
-    var parts = cleanStr.split(options.delimiter, limit);
-
-    for (var i = 0; i < parts.length; ++i) {
-        var part = parts[i];
-
-        var bracketEqualsPos = part.indexOf(']=');
-        var pos = bracketEqualsPos === -1 ? part.indexOf('=') : bracketEqualsPos + 1;
-
-        var key, val;
-        if (pos === -1) {
-            key = options.decoder(part, defaults.decoder);
-            val = options.strictNullHandling ? null : '';
-        } else {
-            key = options.decoder(part.slice(0, pos), defaults.decoder);
-            val = options.decoder(part.slice(pos + 1), defaults.decoder);
-        }
-        if (has.call(obj, key)) {
-            obj[key] = [].concat(obj[key]).concat(val);
-        } else {
-            obj[key] = val;
-        }
-    }
-
-    return obj;
-};
-
-var parseObject = function (chain, val, options) {
-    var leaf = val;
-
-    for (var i = chain.length - 1; i >= 0; --i) {
-        var obj;
-        var root = chain[i];
-
-        if (root === '[]') {
-            obj = [];
-            obj = obj.concat(leaf);
-        } else {
-            obj = options.plainObjects ? Object.create(null) : {};
-            var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
-            var index = parseInt(cleanRoot, 10);
-            if (
-                !isNaN(index)
-                && root !== cleanRoot
-                && String(index) === cleanRoot
-                && index >= 0
-                && (options.parseArrays && index <= options.arrayLimit)
-            ) {
-                obj = [];
-                obj[index] = leaf;
-            } else {
-                obj[cleanRoot] = leaf;
-            }
+    const hexTable = (function () {
+        const array = [];
+        for (let i = 0; i < 256; ++i) {
+            array.push('%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase());
         }
 
-        leaf = obj;
-    }
+        return array;
+    }());
 
-    return leaf;
-};
+    const compactQueue = function compactQueue(queue) {
+        let obj;
 
-var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
-    if (!givenKey) {
-        return;
-    }
+        while (queue.length) {
+            const item = queue.pop();
+            obj = item.obj[item.prop];
 
-    // Transform dot notation to bracket notation
-    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+            if (Array.isArray(obj)) {
+                const compacted = [];
 
-    // The regex chunks
-
-    var brackets = /(\[[^[\]]*])/;
-    var child = /(\[[^[\]]*])/g;
-
-    // Get the parent
-
-    var segment = brackets.exec(key);
-    var parent = segment ? key.slice(0, segment.index) : key;
-
-    // Stash the parent if it exists
-
-    var keys = [];
-    if (parent) {
-        // If we aren't using plain objects, optionally prefix keys
-        // that would overwrite object prototype properties
-        if (!options.plainObjects && has.call(Object.prototype, parent)) {
-            if (!options.allowPrototypes) {
-                return;
-            }
-        }
-
-        keys.push(parent);
-    }
-
-    // Loop through children appending to the array until we hit depth
-
-    var i = 0;
-    while ((segment = child.exec(key)) !== null && i < options.depth) {
-        i += 1;
-        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
-            if (!options.allowPrototypes) {
-                return;
-            }
-        }
-        keys.push(segment[1]);
-    }
-
-    // If there's a remainder, just add whatever is left
-
-    if (segment) {
-        keys.push('[' + key.slice(segment.index) + ']');
-    }
-
-    return parseObject(keys, val, options);
-};
-
-module.exports = function (str, opts) {
-    var options = opts ? utils.assign({}, opts) : {};
-
-    if (options.decoder !== null && options.decoder !== undefined && typeof options.decoder !== 'function') {
-        throw new TypeError('Decoder has to be a function.');
-    }
-
-    options.ignoreQueryPrefix = options.ignoreQueryPrefix === true;
-    options.delimiter = typeof options.delimiter === 'string' || utils.isRegExp(options.delimiter) ? options.delimiter : defaults.delimiter;
-    options.depth = typeof options.depth === 'number' ? options.depth : defaults.depth;
-    options.arrayLimit = typeof options.arrayLimit === 'number' ? options.arrayLimit : defaults.arrayLimit;
-    options.parseArrays = options.parseArrays !== false;
-    options.decoder = typeof options.decoder === 'function' ? options.decoder : defaults.decoder;
-    options.allowDots = typeof options.allowDots === 'boolean' ? options.allowDots : defaults.allowDots;
-    options.plainObjects = typeof options.plainObjects === 'boolean' ? options.plainObjects : defaults.plainObjects;
-    options.allowPrototypes = typeof options.allowPrototypes === 'boolean' ? options.allowPrototypes : defaults.allowPrototypes;
-    options.parameterLimit = typeof options.parameterLimit === 'number' ? options.parameterLimit : defaults.parameterLimit;
-    options.strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
-
-    if (str === '' || str === null || typeof str === 'undefined') {
-        return options.plainObjects ? Object.create(null) : {};
-    }
-
-    var tempObj = typeof str === 'string' ? parseValues(str, options) : str;
-    var obj = options.plainObjects ? Object.create(null) : {};
-
-    // Iterate over the keys and setup the new object
-
-    var keys = Object.keys(tempObj);
-    for (var i = 0; i < keys.length; ++i) {
-        var key = keys[i];
-        var newObj = parseKeys(key, tempObj[key], options);
-        obj = utils.merge(obj, newObj, options);
-    }
-
-    return utils.compact(obj);
-};
-
-},{"./utils":5}],4:[function(require,module,exports){
-'use strict';
-
-var utils = require('./utils');
-var formats = require('./formats');
-
-var arrayPrefixGenerators = {
-    brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
-        return prefix + '[]';
-    },
-    indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
-        return prefix + '[' + key + ']';
-    },
-    repeat: function repeat(prefix) { // eslint-disable-line func-name-matching
-        return prefix;
-    }
-};
-
-var toISO = Date.prototype.toISOString;
-
-var defaults = {
-    delimiter: '&',
-    encode: true,
-    encoder: utils.encode,
-    encodeValuesOnly: false,
-    serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
-        return toISO.call(date);
-    },
-    skipNulls: false,
-    strictNullHandling: false
-};
-
-var stringify = function stringify( // eslint-disable-line func-name-matching
-    object,
-    prefix,
-    generateArrayPrefix,
-    strictNullHandling,
-    skipNulls,
-    encoder,
-    filter,
-    sort,
-    allowDots,
-    serializeDate,
-    formatter,
-    encodeValuesOnly
-) {
-    var obj = object;
-    if (typeof filter === 'function') {
-        obj = filter(prefix, obj);
-    } else if (obj instanceof Date) {
-        obj = serializeDate(obj);
-    } else if (obj === null) {
-        if (strictNullHandling) {
-            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder) : prefix;
-        }
-
-        obj = '';
-    }
-
-    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
-        if (encoder) {
-            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder);
-            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder))];
-        }
-        return [formatter(prefix) + '=' + formatter(String(obj))];
-    }
-
-    var values = [];
-
-    if (typeof obj === 'undefined') {
-        return values;
-    }
-
-    var objKeys;
-    if (Array.isArray(filter)) {
-        objKeys = filter;
-    } else {
-        var keys = Object.keys(obj);
-        objKeys = sort ? keys.sort(sort) : keys;
-    }
-
-    for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-
-        if (skipNulls && obj[key] === null) {
-            continue;
-        }
-
-        if (Array.isArray(obj)) {
-            values = values.concat(stringify(
-                obj[key],
-                generateArrayPrefix(prefix, key),
-                generateArrayPrefix,
-                strictNullHandling,
-                skipNulls,
-                encoder,
-                filter,
-                sort,
-                allowDots,
-                serializeDate,
-                formatter,
-                encodeValuesOnly
-            ));
-        } else {
-            values = values.concat(stringify(
-                obj[key],
-                prefix + (allowDots ? '.' + key : '[' + key + ']'),
-                generateArrayPrefix,
-                strictNullHandling,
-                skipNulls,
-                encoder,
-                filter,
-                sort,
-                allowDots,
-                serializeDate,
-                formatter,
-                encodeValuesOnly
-            ));
-        }
-    }
-
-    return values;
-};
-
-module.exports = function (object, opts) {
-    var obj = object;
-    var options = opts ? utils.assign({}, opts) : {};
-
-    if (options.encoder !== null && options.encoder !== undefined && typeof options.encoder !== 'function') {
-        throw new TypeError('Encoder has to be a function.');
-    }
-
-    var delimiter = typeof options.delimiter === 'undefined' ? defaults.delimiter : options.delimiter;
-    var strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
-    var skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : defaults.skipNulls;
-    var encode = typeof options.encode === 'boolean' ? options.encode : defaults.encode;
-    var encoder = typeof options.encoder === 'function' ? options.encoder : defaults.encoder;
-    var sort = typeof options.sort === 'function' ? options.sort : null;
-    var allowDots = typeof options.allowDots === 'undefined' ? false : options.allowDots;
-    var serializeDate = typeof options.serializeDate === 'function' ? options.serializeDate : defaults.serializeDate;
-    var encodeValuesOnly = typeof options.encodeValuesOnly === 'boolean' ? options.encodeValuesOnly : defaults.encodeValuesOnly;
-    if (typeof options.format === 'undefined') {
-        options.format = formats['default'];
-    } else if (!Object.prototype.hasOwnProperty.call(formats.formatters, options.format)) {
-        throw new TypeError('Unknown format option provided.');
-    }
-    var formatter = formats.formatters[options.format];
-    var objKeys;
-    var filter;
-
-    if (typeof options.filter === 'function') {
-        filter = options.filter;
-        obj = filter('', obj);
-    } else if (Array.isArray(options.filter)) {
-        filter = options.filter;
-        objKeys = filter;
-    }
-
-    var keys = [];
-
-    if (typeof obj !== 'object' || obj === null) {
-        return '';
-    }
-
-    var arrayFormat;
-    if (options.arrayFormat in arrayPrefixGenerators) {
-        arrayFormat = options.arrayFormat;
-    } else if ('indices' in options) {
-        arrayFormat = options.indices ? 'indices' : 'repeat';
-    } else {
-        arrayFormat = 'indices';
-    }
-
-    var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
-
-    if (!objKeys) {
-        objKeys = Object.keys(obj);
-    }
-
-    if (sort) {
-        objKeys.sort(sort);
-    }
-
-    for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-
-        if (skipNulls && obj[key] === null) {
-            continue;
-        }
-
-        keys = keys.concat(stringify(
-            obj[key],
-            key,
-            generateArrayPrefix,
-            strictNullHandling,
-            skipNulls,
-            encode ? encoder : null,
-            filter,
-            sort,
-            allowDots,
-            serializeDate,
-            formatter,
-            encodeValuesOnly
-        ));
-    }
-
-    var joined = keys.join(delimiter);
-    var prefix = options.addQueryPrefix === true ? '?' : '';
-
-    return joined.length > 0 ? prefix + joined : '';
-};
-
-},{"./formats":1,"./utils":5}],5:[function(require,module,exports){
-'use strict';
-
-var has = Object.prototype.hasOwnProperty;
-
-var hexTable = (function () {
-    var array = [];
-    for (var i = 0; i < 256; ++i) {
-        array.push('%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase());
-    }
-
-    return array;
-}());
-
-var compactQueue = function compactQueue(queue) {
-    var obj;
-
-    while (queue.length) {
-        var item = queue.pop();
-        obj = item.obj[item.prop];
-
-        if (Array.isArray(obj)) {
-            var compacted = [];
-
-            for (var j = 0; j < obj.length; ++j) {
-                if (typeof obj[j] !== 'undefined') {
-                    compacted.push(obj[j]);
+                for (let j = 0; j < obj.length; ++j) {
+                    if (typeof obj[j] !== 'undefined') {
+                        compacted.push(obj[j]);
+                    }
                 }
+
+                item.obj[item.prop] = compacted;
+            }
+        }
+
+        return obj;
+    };
+
+    const arrayToObject = function arrayToObject(source, options) {
+        const obj = options && options.plainObjects ? Object.create(null) : {};
+        for (let i = 0; i < source.length; ++i) {
+            if (typeof source[i] !== 'undefined') {
+                obj[i] = source[i];
+            }
+        }
+
+        return obj;
+    };
+
+    const merge = function merge(target, source, options) {
+        if (!source) {
+            return target;
+        }
+
+        if (typeof source !== 'object') {
+            if (Array.isArray(target)) {
+                target.push(source);
+            } else if (typeof target === 'object') {
+                if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
+                    target[source] = true;
+                }
+            } else {
+                return [target, source];
             }
 
-            item.obj[item.prop] = compacted;
-        }
-    }
-
-    return obj;
-};
-
-var arrayToObject = function arrayToObject(source, options) {
-    var obj = options && options.plainObjects ? Object.create(null) : {};
-    for (var i = 0; i < source.length; ++i) {
-        if (typeof source[i] !== 'undefined') {
-            obj[i] = source[i];
-        }
-    }
-
-    return obj;
-};
-
-var merge = function merge(target, source, options) {
-    if (!source) {
-        return target;
-    }
-
-    if (typeof source !== 'object') {
-        if (Array.isArray(target)) {
-            target.push(source);
-        } else if (typeof target === 'object') {
-            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
-                target[source] = true;
-            }
-        } else {
-            return [target, source];
+            return target;
         }
 
-        return target;
-    }
+        if (typeof target !== 'object') {
+            return [target].concat(source);
+        }
 
-    if (typeof target !== 'object') {
-        return [target].concat(source);
-    }
+        let mergeTarget = target;
+        if (Array.isArray(target) && !Array.isArray(source)) {
+            mergeTarget = arrayToObject(target, options);
+        }
 
-    var mergeTarget = target;
-    if (Array.isArray(target) && !Array.isArray(source)) {
-        mergeTarget = arrayToObject(target, options);
-    }
-
-    if (Array.isArray(target) && Array.isArray(source)) {
-        source.forEach(function (item, i) {
-            if (has.call(target, i)) {
-                if (target[i] && typeof target[i] === 'object') {
-                    target[i] = merge(target[i], item, options);
+        if (Array.isArray(target) && Array.isArray(source)) {
+            source.forEach(function (item, i) {
+                if (has.call(target, i)) {
+                    if (target[i] && typeof target[i] === 'object') {
+                        target[i] = merge(target[i], item, options);
+                    } else {
+                        target.push(item);
+                    }
                 } else {
-                    target.push(item);
+                    target[i] = item;
                 }
+            });
+            return target;
+        }
+
+        return Object.keys(source).reduce(function (acc, key) {
+            const value = source[key];
+
+            if (has.call(acc, key)) {
+                acc[key] = merge(acc[key], value, options);
             } else {
-                target[i] = item;
+                acc[key] = value;
             }
+            return acc;
+        }, mergeTarget);
+    };
+
+    const assign = function assign(target, source) {
+        return Object.keys(source).reduce(function (acc, key) {
+            acc[key] = source[key];
+            return acc;
+        }, target);
+    };
+
+    const decode = function decode(str, decoder, charset) {
+        const strWithoutPlus = str.replace(/\+/g, ' ');
+        if (charset === 'iso-8859-1') {
+            // unescape never throws, no try...catch needed:
+            return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
+        }
+        // utf-8
+        try {
+            return decodeURIComponent(strWithoutPlus);
+        } catch (e) {
+            return strWithoutPlus;
+        }
+    };
+
+    const encode = function encode(str, defaultEncoder, charset) {
+        // This code was originally written by Brian White (mscdex) for the io.js core querystring library.
+        // It has been adapted here for stricter adherence to RFC 3986
+        if (str.length === 0) {
+            return str;
+        }
+
+        const string = typeof str === 'string' ? str : String(str);
+
+        if (charset === 'iso-8859-1') {
+            return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
+                return '%26%23' + parseInt($0.slice(2), 16) + '%3B';
+            });
+        }
+
+        let out = '';
+        for (let i = 0; i < string.length; ++i) {
+            let c = string.charCodeAt(i);
+
+            if (
+                c === 0x2D // -
+                || c === 0x2E // .
+                || c === 0x5F // _
+                || c === 0x7E // ~
+                || (c >= 0x30 && c <= 0x39) // 0-9
+                || (c >= 0x41 && c <= 0x5A) // a-z
+                || (c >= 0x61 && c <= 0x7A) // A-Z
+            ) {
+                out += string.charAt(i);
+                continue;
+            }
+
+            if (c < 0x80) {
+                out = out + hexTable[c];
+                continue;
+            }
+
+            if (c < 0x800) {
+                out = out + (hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)]);
+                continue;
+            }
+
+            if (c < 0xD800 || c >= 0xE000) {
+                out = out + (hexTable[0xE0 | (c >> 12)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)]);
+                continue;
+            }
+
+            i += 1;
+            c = 0x10000 + (((c & 0x3FF) << 10) | (string.charCodeAt(i) & 0x3FF));
+            out += hexTable[0xF0 | (c >> 18)]
+                + hexTable[0x80 | ((c >> 12) & 0x3F)]
+                + hexTable[0x80 | ((c >> 6) & 0x3F)]
+                + hexTable[0x80 | (c & 0x3F)];
+        }
+
+        return out;
+    };
+
+    const compact = function compact(value) {
+        const queue = [{ obj: { o: value }, prop: 'o' }];
+        const refs = [];
+
+        for (let i = 0; i < queue.length; ++i) {
+            const item = queue[i];
+            const obj = item.obj[item.prop];
+
+            const keys = Object.keys(obj);
+            for (let j = 0; j < keys.length; ++j) {
+                const key = keys[j];
+                const val = obj[key];
+                if (typeof val === 'object' && val !== null && refs.indexOf(val) === -1) {
+                    queue.push({ obj: obj, prop: key });
+                    refs.push(val);
+                }
+            }
+        }
+
+        return compactQueue(queue);
+    };
+
+    const isRegExp = function isRegExp(obj) {
+        return Object.prototype.toString.call(obj) === '[object RegExp]';
+    };
+
+    const isBuffer = function isBuffer(obj) {
+        if (obj === null || typeof obj === 'undefined') {
+            return false;
+        }
+
+        return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
+    };
+
+    const has$1 = Object.prototype.hasOwnProperty;
+    const defaults = {
+        allowDots: false,
+        allowPrototypes: false,
+        arrayLimit: 20,
+        charset: 'utf-8',
+        charsetSentinel: false,
+        decoder: decode,
+        delimiter: '&',
+        depth: 5,
+        interpretNumericEntities: false,
+        parameterLimit: 1000,
+        plainObjects: false,
+        strictNullHandling: false
+    };
+
+    const interpretNumericEntities = function (str) {
+        return str.replace(/&#(\d+);/g, function ($0, numberStr) {
+            return String.fromCharCode(parseInt(numberStr, 10));
         });
-        return target;
-    }
+    };
 
-    return Object.keys(source).reduce(function (acc, key) {
-        var value = source[key];
+    // This is what browsers will submit when the ✓ character occurs in an
+    // application/x-www-form-urlencoded body and the encoding of the page containing
+    // the form is iso-8859-1, or when the submitted form has an accept-charset
+    // attribute of iso-8859-1. Presumably also with other charsets that do not contain
+    // the ✓ character, such as us-ascii.
+    const isoSentinel = 'utf8=%26%2310003%3B'; // encodeURIComponent('&#10003;')
 
-        if (has.call(acc, key)) {
-            acc[key] = merge(acc[key], value, options);
-        } else {
-            acc[key] = value;
-        }
-        return acc;
-    }, mergeTarget);
-};
+    // These are the percent-encoded utf-8 octets representing a checkmark, indicating
+    // that the request actually is utf-8 encoded.
+    const charsetSentinel = 'utf8=%E2%9C%93'; // encodeURIComponent('✓')
 
-var assign = function assignSingleSource(target, source) {
-    return Object.keys(source).reduce(function (acc, key) {
-        acc[key] = source[key];
-        return acc;
-    }, target);
-};
+    const parseValues = function parseQueryStringValues(str, options) {
+        const obj = {};
+        const cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
+        const limit = options.parameterLimit === Infinity ? undefined : options.parameterLimit;
+        const parts = cleanStr.split(options.delimiter, limit);
+        let charset = options.charset;
+        let skipIndex = -1; // Keep track of where the utf8 sentinel was found
 
-var decode = function (str) {
-    try {
-        return decodeURIComponent(str.replace(/\+/g, ' '));
-    } catch (e) {
-        return str;
-    }
-};
-
-var encode = function encode(str) {
-    // This code was originally written by Brian White (mscdex) for the io.js core querystring library.
-    // It has been adapted here for stricter adherence to RFC 3986
-    if (str.length === 0) {
-        return str;
-    }
-
-    var string = typeof str === 'string' ? str : String(str);
-
-    var out = '';
-    for (var i = 0; i < string.length; ++i) {
-        var c = string.charCodeAt(i);
-
-        if (
-            c === 0x2D // -
-            || c === 0x2E // .
-            || c === 0x5F // _
-            || c === 0x7E // ~
-            || (c >= 0x30 && c <= 0x39) // 0-9
-            || (c >= 0x41 && c <= 0x5A) // a-z
-            || (c >= 0x61 && c <= 0x7A) // A-Z
-        ) {
-            out += string.charAt(i);
-            continue;
+        if (charset !== undefined && charset !== 'utf-8' && charset !== 'iso-8859-1') {
+            throw new Error('The charset option must be either utf-8, iso-8859-1, or undefined');
         }
 
-        if (c < 0x80) {
-            out = out + hexTable[c];
-            continue;
-        }
-
-        if (c < 0x800) {
-            out = out + (hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)]);
-            continue;
-        }
-
-        if (c < 0xD800 || c >= 0xE000) {
-            out = out + (hexTable[0xE0 | (c >> 12)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)]);
-            continue;
-        }
-
-        i += 1;
-        c = 0x10000 + (((c & 0x3FF) << 10) | (string.charCodeAt(i) & 0x3FF));
-        out += hexTable[0xF0 | (c >> 18)]
-            + hexTable[0x80 | ((c >> 12) & 0x3F)]
-            + hexTable[0x80 | ((c >> 6) & 0x3F)]
-            + hexTable[0x80 | (c & 0x3F)];
-    }
-
-    return out;
-};
-
-var compact = function compact(value) {
-    var queue = [{ obj: { o: value }, prop: 'o' }];
-    var refs = [];
-
-    for (var i = 0; i < queue.length; ++i) {
-        var item = queue[i];
-        var obj = item.obj[item.prop];
-
-        var keys = Object.keys(obj);
-        for (var j = 0; j < keys.length; ++j) {
-            var key = keys[j];
-            var val = obj[key];
-            if (typeof val === 'object' && val !== null && refs.indexOf(val) === -1) {
-                queue.push({ obj: obj, prop: key });
-                refs.push(val);
+        if (options.charsetSentinel) {
+            for (let i = 0; i < parts.length; ++i) {
+                if (parts[i].indexOf('utf8=') === 0) {
+                    if (parts[i] === charsetSentinel) {
+                        charset = 'utf-8';
+                    } else if (parts[i] === isoSentinel) {
+                        charset = 'iso-8859-1';
+                    }
+                    skipIndex = i;
+                    i = parts.length; // The eslint settings do not allow break;
+                }
             }
         }
+
+        for (let i = 0; i < parts.length; ++i) {
+            if (i === skipIndex) {
+                continue;
+            }
+
+            const part = parts[i];
+            const bracketEqualsPos = part.indexOf(']=');
+            const pos = bracketEqualsPos === -1 ? part.indexOf('=') : bracketEqualsPos + 1;
+
+            let key;
+            let val;
+
+            if (pos === -1) {
+                key = options.decoder(part, defaults.decoder, charset);
+                val = options.strictNullHandling ? null : '';
+            } else {
+                key = options.decoder(part.slice(0, pos), defaults.decoder, charset);
+                val = options.decoder(part.slice(pos + 1), defaults.decoder, charset);
+            }
+
+            if (options.interpretNumericEntities && charset === 'iso-8859-1') {
+                val = interpretNumericEntities(val);
+            }
+
+            if (has$1.call(obj, key)) {
+                obj[key] = [].concat(obj[key]).concat(val);
+            } else {
+                obj[key] = val;
+            }
+        }
+
+        return obj;
+    };
+
+    const parseObject = function (chain, val, options) {
+        let leaf = val;
+
+        for (let i = chain.length - 1; i >= 0; --i) {
+            let obj;
+            const root = chain[i];
+
+            if (root === '[]' && options.parseArrays) {
+                obj = [].concat(leaf);
+            } else {
+                obj = options.plainObjects ? Object.create(null) : {};
+                const cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
+                const index = parseInt(cleanRoot, 10);
+                if (!options.parseArrays && cleanRoot === '') {
+                    obj = { 0: leaf };
+                } else if (
+                    !isNaN(index)
+                    && root !== cleanRoot
+                    && String(index) === cleanRoot
+                    && index >= 0
+                    && (options.parseArrays && index <= options.arrayLimit)
+                ) {
+                    obj = [];
+                    obj[index] = leaf;
+                } else {
+                    obj[cleanRoot] = leaf;
+                }
+            }
+
+            leaf = obj;
+        }
+
+        return leaf;
+    };
+
+    const parseKeys = function parseQueryStringKeys(givenKey, val, options) {
+        if (!givenKey) {
+            return;
+        }
+
+        // Transform dot notation to bracket notation
+        const key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+
+        // The regex chunks
+        const brackets = /(\[[^[\]]*])/;
+        const child = /(\[[^[\]]*])/g;
+
+        // Get the parent
+        let segment = brackets.exec(key);
+        const parent = segment ? key.slice(0, segment.index) : key;
+
+        // Stash the parent if it exists
+        const keys = [];
+
+        if (parent) {
+            // If we aren't using plain objects, optionally prefix keys
+            // that would overwrite object prototype properties
+            if (!options.plainObjects && has$1.call(Object.prototype, parent)) {
+                if (!options.allowPrototypes) {
+                    return;
+                }
+            }
+
+            keys.push(parent);
+        }
+
+        // Loop through children appending to the array until we hit depth
+        let i = 0;
+
+        while ((segment = child.exec(key)) !== null && i < options.depth) {
+            i += 1;
+            if (!options.plainObjects && has$1.call(Object.prototype, segment[1].slice(1, -1))) {
+                if (!options.allowPrototypes) {
+                    return;
+                }
+            }
+            keys.push(segment[1]);
+        }
+
+        // If there's a remainder, just add whatever is left
+        if (segment) {
+            keys.push('[' + key.slice(segment.index) + ']');
+        }
+
+        return parseObject(keys, val, options);
+    };
+
+    function parse(str, opts) {
+        const options = opts ? assign({}, opts) : {};
+
+        if (options.decoder !== null && options.decoder !== undefined && typeof options.decoder !== 'function') {
+            throw new TypeError('Decoder has to be a function.');
+        }
+
+        options.ignoreQueryPrefix = options.ignoreQueryPrefix === true;
+        options.delimiter = typeof options.delimiter === 'string' || isRegExp(options.delimiter) ? options.delimiter : defaults.delimiter;
+        options.depth = typeof options.depth === 'number' ? options.depth : defaults.depth;
+        options.arrayLimit = typeof options.arrayLimit === 'number' ? options.arrayLimit : defaults.arrayLimit;
+        options.parseArrays = options.parseArrays !== false;
+        options.decoder = typeof options.decoder === 'function' ? options.decoder : defaults.decoder;
+        options.allowDots = typeof options.allowDots === 'boolean' ? options.allowDots : defaults.allowDots;
+        options.plainObjects = typeof options.plainObjects === 'boolean' ? options.plainObjects : defaults.plainObjects;
+        options.allowPrototypes = typeof options.allowPrototypes === 'boolean' ? options.allowPrototypes : defaults.allowPrototypes;
+        options.parameterLimit = typeof options.parameterLimit === 'number' ? options.parameterLimit : defaults.parameterLimit;
+        options.strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
+
+        if (str === '' || str === null || typeof str === 'undefined') {
+            return options.plainObjects ? Object.create(null) : {};
+        }
+
+        const tempObj = typeof str === 'string' ? parseValues(str, options) : str;
+        let obj = options.plainObjects ? Object.create(null) : {};
+
+        // Iterate over the keys and setup the new object
+
+        const keys = Object.keys(tempObj);
+        for (let i = 0; i < keys.length; ++i) {
+            const key = keys[i];
+            const newObj = parseKeys(key, tempObj[key], options);
+            obj = merge(obj, newObj, options);
+        }
+
+        return compact(obj);
     }
 
-    return compactQueue(queue);
-};
+    const arrayPrefixGenerators = {
+        brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
+            return prefix + '[]';
+        },
+        indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
+            return prefix + '[' + key + ']';
+        },
+        repeat: function repeat(prefix) { // eslint-disable-line func-name-matching
+            return prefix;
+        }
+    };
 
-var isRegExp = function isRegExp(obj) {
-    return Object.prototype.toString.call(obj) === '[object RegExp]';
-};
+    const toISO = Date.prototype.toISOString;
 
-var isBuffer = function isBuffer(obj) {
-    if (obj === null || typeof obj === 'undefined') {
-        return false;
+    const defaults$1 = {
+        delimiter: '&',
+        encode: true,
+        encoder: encode,
+        encodeValuesOnly: false,
+        serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
+            return toISO.call(date);
+        },
+        skipNulls: false,
+        strictNullHandling: false
+    };
+
+    const stringify = function stringify( // eslint-disable-line func-name-matching
+        object,
+        prefix,
+        generateArrayPrefix,
+        strictNullHandling,
+        skipNulls,
+        encoder,
+        filter,
+        sort,
+        allowDots,
+        serializeDate,
+        formatter,
+        encodeValuesOnly,
+        charset
+    ) {
+        let obj = object;
+        if (typeof filter === 'function') {
+            obj = filter(prefix, obj);
+        } else if (obj instanceof Date) {
+            obj = serializeDate(obj);
+        } else if (obj === null) {
+            if (strictNullHandling) {
+                return encoder && !encodeValuesOnly ? encoder(prefix, defaults$1.encoder, charset) : prefix;
+            }
+
+            obj = '';
+        }
+
+        if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || isBuffer(obj)) {
+            if (encoder) {
+                const keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults$1.encoder, charset);
+                return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults$1.encoder, charset))];
+            }
+            return [formatter(prefix) + '=' + formatter(String(obj))];
+        }
+
+        let values = [];
+
+        if (typeof obj === 'undefined') {
+            return values;
+        }
+
+        let objKeys;
+        if (Array.isArray(filter)) {
+            objKeys = filter;
+        } else {
+            const keys = Object.keys(obj);
+            objKeys = sort ? keys.sort(sort) : keys;
+        }
+
+        for (let i = 0; i < objKeys.length; ++i) {
+            const key = objKeys[i];
+
+            if (skipNulls && obj[key] === null) {
+                continue;
+            }
+
+            if (Array.isArray(obj)) {
+                values = values.concat(stringify(
+                    obj[key],
+                    generateArrayPrefix(prefix, key),
+                    generateArrayPrefix,
+                    strictNullHandling,
+                    skipNulls,
+                    encoder,
+                    filter,
+                    sort,
+                    allowDots,
+                    serializeDate,
+                    formatter,
+                    encodeValuesOnly,
+                    charset
+                ));
+            } else {
+                values = values.concat(stringify(
+                    obj[key],
+                    prefix + (allowDots ? '.' + key : '[' + key + ']'),
+                    generateArrayPrefix,
+                    strictNullHandling,
+                    skipNulls,
+                    encoder,
+                    filter,
+                    sort,
+                    allowDots,
+                    serializeDate,
+                    formatter,
+                    encodeValuesOnly,
+                    charset
+                ));
+            }
+        }
+
+        return values;
+    };
+
+    function stringify$1 (object, opts) {
+        let obj = object;
+        const options = opts ? assign({}, opts) : {};
+
+        if (options.encoder !== null && options.encoder !== undefined && typeof options.encoder !== 'function') {
+            throw new TypeError('Encoder has to be a function.');
+        }
+
+        const delimiter = typeof options.delimiter === 'undefined' ? defaults$1.delimiter : options.delimiter;
+        const strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults$1.strictNullHandling;
+        const skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : defaults$1.skipNulls;
+        const encode$$1 = typeof options.encode === 'boolean' ? options.encode : defaults$1.encode;
+        const encoder = typeof options.encoder === 'function' ? options.encoder : defaults$1.encoder;
+        const sort = typeof options.sort === 'function' ? options.sort : null;
+        const allowDots = typeof options.allowDots === 'undefined' ? false : options.allowDots;
+        const serializeDate = typeof options.serializeDate === 'function' ? options.serializeDate : defaults$1.serializeDate;
+        const encodeValuesOnly = typeof options.encodeValuesOnly === 'boolean' ? options.encodeValuesOnly : defaults$1.encodeValuesOnly;
+        const charset = options.charset || 'utf-8';
+        if (charset !== undefined && charset !== 'utf-8' && charset !== 'iso-8859-1') {
+            throw new Error('The charset option must be either utf-8, iso-8859-1, or undefined');
+        }
+
+        if (typeof options.format === 'undefined') {
+            options.format = RFC3986;
+        } else if (!Object.prototype.hasOwnProperty.call(formatters, options.format)) {
+            throw new TypeError('Unknown format option provided.');
+        }
+        const formatter = formatters[options.format];
+        let objKeys;
+        let filter;
+
+        if (typeof options.filter === 'function') {
+            filter = options.filter;
+            obj = filter('', obj);
+        } else if (Array.isArray(options.filter)) {
+            filter = options.filter;
+            objKeys = filter;
+        }
+
+        let keys = [];
+
+        if (typeof obj !== 'object' || obj === null) {
+            return '';
+        }
+
+        let arrayFormat;
+        if (options.arrayFormat in arrayPrefixGenerators) {
+            arrayFormat = options.arrayFormat;
+        } else if ('indices' in options) {
+            arrayFormat = options.indices ? 'indices' : 'repeat';
+        } else {
+            arrayFormat = 'indices';
+        }
+
+        const generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
+
+        if (!objKeys) {
+            objKeys = Object.keys(obj);
+        }
+
+        if (sort) {
+            objKeys.sort(sort);
+        }
+
+        for (let i = 0; i < objKeys.length; ++i) {
+            const key = objKeys[i];
+
+            if (skipNulls && obj[key] === null) {
+                continue;
+            }
+
+            keys = keys.concat(stringify(
+                obj[key],
+                key,
+                generateArrayPrefix,
+                strictNullHandling,
+                skipNulls,
+                encode$$1 ? encoder : null,
+                filter,
+                sort,
+                allowDots,
+                serializeDate,
+                formatter,
+                encodeValuesOnly,
+                charset
+            ));
+        }
+
+        const joined = keys.join(delimiter);
+        let prefix = options.addQueryPrefix === true ? '?' : '';
+
+        if (options.charsetSentinel) {
+            if (charset === 'iso-8859-1') {
+                // encodeURIComponent('&#10003;'), the "numeric entity" representation of a checkmark
+                prefix += 'utf8=%26%2310003%3B&';
+            } else {
+                // encodeURIComponent('ÃÂ¢ÃÂÃÂ')
+                prefix += 'utf8=%E2%9C%93&';
+            }
+        }
+
+        return joined.length > 0 ? prefix + joined : '';
     }
 
-    return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
-};
+    exports.formats = formats;
+    exports.parse = parse;
+    exports.stringify = stringify$1;
 
-module.exports = {
-    arrayToObject: arrayToObject,
-    assign: assign,
-    compact: compact,
-    decode: decode,
-    encode: encode,
-    isBuffer: isBuffer,
-    isRegExp: isRegExp,
-    merge: merge
-};
+    Object.defineProperty(exports, '__esModule', { value: true });
 
-},{}]},{},[2])(2)
-});
+})));

--- a/lib/formats.js
+++ b/lib/formats.js
@@ -1,18 +1,15 @@
-'use strict';
+const replace = String.prototype.replace;
+const percentTwenties = /%20/g;
 
-var replace = String.prototype.replace;
-var percentTwenties = /%20/g;
-
-module.exports = {
-    'default': 'RFC3986',
-    formatters: {
-        RFC1738: function (value) {
-            return replace.call(value, percentTwenties, '+');
-        },
-        RFC3986: function (value) {
-            return value;
-        }
+export const formatters = {
+    RFC1738: function (value) {
+        return replace.call(value, percentTwenties, '+');
     },
-    RFC1738: 'RFC1738',
-    RFC3986: 'RFC3986'
+    RFC3986: function (value) {
+        return value;
+    }
 };
+
+export const RFC1738 = 'RFC1738';
+export const RFC3986 = 'RFC3986';
+export default RFC3986;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,5 @@
-'use strict';
+import * as formats from './formats.js';
 
-var stringify = require('./stringify');
-var parse = require('./parse');
-var formats = require('./formats');
-
-module.exports = {
-    formats: formats,
-    parse: parse,
-    stringify: stringify
-};
+export { formats };
+export { default as parse } from './parse.js';
+export { default as stringify } from './stringify.js';

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,10 +1,7 @@
-'use strict';
+import * as utils from './utils.js';
 
-var utils = require('./utils');
-
-var has = Object.prototype.hasOwnProperty;
-
-var defaults = {
+const has = Object.prototype.hasOwnProperty;
+const defaults = {
     allowDots: false,
     allowPrototypes: false,
     arrayLimit: 20,
@@ -19,7 +16,7 @@ var defaults = {
     strictNullHandling: false
 };
 
-var interpretNumericEntities = function (str) {
+const interpretNumericEntities = function (str) {
     return str.replace(/&#(\d+);/g, function ($0, numberStr) {
         return String.fromCharCode(parseInt(numberStr, 10));
     });
@@ -30,26 +27,26 @@ var interpretNumericEntities = function (str) {
 // the form is iso-8859-1, or when the submitted form has an accept-charset
 // attribute of iso-8859-1. Presumably also with other charsets that do not contain
 // the ✓ character, such as us-ascii.
-var isoSentinel = 'utf8=%26%2310003%3B'; // encodeURIComponent('&#10003;')
+const isoSentinel = 'utf8=%26%2310003%3B'; // encodeURIComponent('&#10003;')
 
 // These are the percent-encoded utf-8 octets representing a checkmark, indicating
 // that the request actually is utf-8 encoded.
-var charsetSentinel = 'utf8=%E2%9C%93'; // encodeURIComponent('✓')
+const charsetSentinel = 'utf8=%E2%9C%93'; // encodeURIComponent('✓')
 
-var parseValues = function parseQueryStringValues(str, options) {
-    var obj = {};
-    var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
-    var limit = options.parameterLimit === Infinity ? undefined : options.parameterLimit;
-    var parts = cleanStr.split(options.delimiter, limit);
-    var charset = options.charset;
-    var skipIndex = -1; // Keep track of where the utf8 sentinel was found
-    var i;
+const parseValues = function parseQueryStringValues(str, options) {
+    const obj = {};
+    const cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
+    const limit = options.parameterLimit === Infinity ? undefined : options.parameterLimit;
+    const parts = cleanStr.split(options.delimiter, limit);
+    let charset = options.charset;
+    let skipIndex = -1; // Keep track of where the utf8 sentinel was found
 
     if (charset !== undefined && charset !== 'utf-8' && charset !== 'iso-8859-1') {
         throw new Error('The charset option must be either utf-8, iso-8859-1, or undefined');
     }
+
     if (options.charsetSentinel) {
-        for (i = 0; i < parts.length; ++i) {
+        for (let i = 0; i < parts.length; ++i) {
             if (parts[i].indexOf('utf8=') === 0) {
                 if (parts[i] === charsetSentinel) {
                     charset = 'utf-8';
@@ -62,16 +59,18 @@ var parseValues = function parseQueryStringValues(str, options) {
         }
     }
 
-    for (i = 0; i < parts.length; ++i) {
+    for (let i = 0; i < parts.length; ++i) {
         if (i === skipIndex) {
             continue;
         }
-        var part = parts[i];
 
-        var bracketEqualsPos = part.indexOf(']=');
-        var pos = bracketEqualsPos === -1 ? part.indexOf('=') : bracketEqualsPos + 1;
+        const part = parts[i];
+        const bracketEqualsPos = part.indexOf(']=');
+        const pos = bracketEqualsPos === -1 ? part.indexOf('=') : bracketEqualsPos + 1;
 
-        var key, val;
+        let key;
+        let val;
+
         if (pos === -1) {
             key = options.decoder(part, defaults.decoder, charset);
             val = options.strictNullHandling ? null : '';
@@ -83,6 +82,7 @@ var parseValues = function parseQueryStringValues(str, options) {
         if (options.interpretNumericEntities && charset === 'iso-8859-1') {
             val = interpretNumericEntities(val);
         }
+
         if (has.call(obj, key)) {
             obj[key] = [].concat(obj[key]).concat(val);
         } else {
@@ -93,19 +93,19 @@ var parseValues = function parseQueryStringValues(str, options) {
     return obj;
 };
 
-var parseObject = function (chain, val, options) {
-    var leaf = val;
+const parseObject = function (chain, val, options) {
+    let leaf = val;
 
-    for (var i = chain.length - 1; i >= 0; --i) {
-        var obj;
-        var root = chain[i];
+    for (let i = chain.length - 1; i >= 0; --i) {
+        let obj;
+        const root = chain[i];
 
         if (root === '[]' && options.parseArrays) {
             obj = [].concat(leaf);
         } else {
             obj = options.plainObjects ? Object.create(null) : {};
-            var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
-            var index = parseInt(cleanRoot, 10);
+            const cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
+            const index = parseInt(cleanRoot, 10);
             if (!options.parseArrays && cleanRoot === '') {
                 obj = { 0: leaf };
             } else if (
@@ -128,27 +128,25 @@ var parseObject = function (chain, val, options) {
     return leaf;
 };
 
-var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
+const parseKeys = function parseQueryStringKeys(givenKey, val, options) {
     if (!givenKey) {
         return;
     }
 
     // Transform dot notation to bracket notation
-    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+    const key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
 
     // The regex chunks
-
-    var brackets = /(\[[^[\]]*])/;
-    var child = /(\[[^[\]]*])/g;
+    const brackets = /(\[[^[\]]*])/;
+    const child = /(\[[^[\]]*])/g;
 
     // Get the parent
-
-    var segment = brackets.exec(key);
-    var parent = segment ? key.slice(0, segment.index) : key;
+    let segment = brackets.exec(key);
+    const parent = segment ? key.slice(0, segment.index) : key;
 
     // Stash the parent if it exists
+    const keys = [];
 
-    var keys = [];
     if (parent) {
         // If we aren't using plain objects, optionally prefix keys
         // that would overwrite object prototype properties
@@ -162,8 +160,8 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
     }
 
     // Loop through children appending to the array until we hit depth
+    let i = 0;
 
-    var i = 0;
     while ((segment = child.exec(key)) !== null && i < options.depth) {
         i += 1;
         if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
@@ -175,7 +173,6 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
     }
 
     // If there's a remainder, just add whatever is left
-
     if (segment) {
         keys.push('[' + key.slice(segment.index) + ']');
     }
@@ -183,8 +180,8 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
     return parseObject(keys, val, options);
 };
 
-module.exports = function (str, opts) {
-    var options = opts ? utils.assign({}, opts) : {};
+export default function parse(str, opts) {
+    const options = opts ? utils.assign({}, opts) : {};
 
     if (options.decoder !== null && options.decoder !== undefined && typeof options.decoder !== 'function') {
         throw new TypeError('Decoder has to be a function.');
@@ -206,17 +203,17 @@ module.exports = function (str, opts) {
         return options.plainObjects ? Object.create(null) : {};
     }
 
-    var tempObj = typeof str === 'string' ? parseValues(str, options) : str;
-    var obj = options.plainObjects ? Object.create(null) : {};
+    const tempObj = typeof str === 'string' ? parseValues(str, options) : str;
+    let obj = options.plainObjects ? Object.create(null) : {};
 
     // Iterate over the keys and setup the new object
 
-    var keys = Object.keys(tempObj);
-    for (var i = 0; i < keys.length; ++i) {
-        var key = keys[i];
-        var newObj = parseKeys(key, tempObj[key], options);
+    const keys = Object.keys(tempObj);
+    for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
+        const newObj = parseKeys(key, tempObj[key], options);
         obj = utils.merge(obj, newObj, options);
     }
 
     return utils.compact(obj);
-};
+}

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,9 +1,7 @@
-'use strict';
+import * as utils from './utils.js';
+import * as formats from './formats.js';
 
-var utils = require('./utils');
-var formats = require('./formats');
-
-var arrayPrefixGenerators = {
+const arrayPrefixGenerators = {
     brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
         return prefix + '[]';
     },
@@ -15,9 +13,9 @@ var arrayPrefixGenerators = {
     }
 };
 
-var toISO = Date.prototype.toISOString;
+const toISO = Date.prototype.toISOString;
 
-var defaults = {
+const defaults = {
     delimiter: '&',
     encode: true,
     encoder: utils.encode,
@@ -29,7 +27,7 @@ var defaults = {
     strictNullHandling: false
 };
 
-var stringify = function stringify( // eslint-disable-line func-name-matching
+const stringify = function stringify( // eslint-disable-line func-name-matching
     object,
     prefix,
     generateArrayPrefix,
@@ -44,7 +42,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
     encodeValuesOnly,
     charset
 ) {
-    var obj = object;
+    let obj = object;
     if (typeof filter === 'function') {
         obj = filter(prefix, obj);
     } else if (obj instanceof Date) {
@@ -59,28 +57,28 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
 
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
         if (encoder) {
-            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset);
+            const keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset);
             return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset))];
         }
         return [formatter(prefix) + '=' + formatter(String(obj))];
     }
 
-    var values = [];
+    let values = [];
 
     if (typeof obj === 'undefined') {
         return values;
     }
 
-    var objKeys;
+    let objKeys;
     if (Array.isArray(filter)) {
         objKeys = filter;
     } else {
-        var keys = Object.keys(obj);
+        const keys = Object.keys(obj);
         objKeys = sort ? keys.sort(sort) : keys;
     }
 
-    for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
+    for (let i = 0; i < objKeys.length; ++i) {
+        const key = objKeys[i];
 
         if (skipNulls && obj[key] === null) {
             continue;
@@ -124,24 +122,24 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
     return values;
 };
 
-module.exports = function (object, opts) {
-    var obj = object;
-    var options = opts ? utils.assign({}, opts) : {};
+export default function (object, opts) {
+    let obj = object;
+    const options = opts ? utils.assign({}, opts) : {};
 
     if (options.encoder !== null && options.encoder !== undefined && typeof options.encoder !== 'function') {
         throw new TypeError('Encoder has to be a function.');
     }
 
-    var delimiter = typeof options.delimiter === 'undefined' ? defaults.delimiter : options.delimiter;
-    var strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
-    var skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : defaults.skipNulls;
-    var encode = typeof options.encode === 'boolean' ? options.encode : defaults.encode;
-    var encoder = typeof options.encoder === 'function' ? options.encoder : defaults.encoder;
-    var sort = typeof options.sort === 'function' ? options.sort : null;
-    var allowDots = typeof options.allowDots === 'undefined' ? false : options.allowDots;
-    var serializeDate = typeof options.serializeDate === 'function' ? options.serializeDate : defaults.serializeDate;
-    var encodeValuesOnly = typeof options.encodeValuesOnly === 'boolean' ? options.encodeValuesOnly : defaults.encodeValuesOnly;
-    var charset = options.charset || 'utf-8';
+    const delimiter = typeof options.delimiter === 'undefined' ? defaults.delimiter : options.delimiter;
+    const strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
+    const skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : defaults.skipNulls;
+    const encode = typeof options.encode === 'boolean' ? options.encode : defaults.encode;
+    const encoder = typeof options.encoder === 'function' ? options.encoder : defaults.encoder;
+    const sort = typeof options.sort === 'function' ? options.sort : null;
+    const allowDots = typeof options.allowDots === 'undefined' ? false : options.allowDots;
+    const serializeDate = typeof options.serializeDate === 'function' ? options.serializeDate : defaults.serializeDate;
+    const encodeValuesOnly = typeof options.encodeValuesOnly === 'boolean' ? options.encodeValuesOnly : defaults.encodeValuesOnly;
+    const charset = options.charset || 'utf-8';
     if (charset !== undefined && charset !== 'utf-8' && charset !== 'iso-8859-1') {
         throw new Error('The charset option must be either utf-8, iso-8859-1, or undefined');
     }
@@ -151,9 +149,9 @@ module.exports = function (object, opts) {
     } else if (!Object.prototype.hasOwnProperty.call(formats.formatters, options.format)) {
         throw new TypeError('Unknown format option provided.');
     }
-    var formatter = formats.formatters[options.format];
-    var objKeys;
-    var filter;
+    const formatter = formats.formatters[options.format];
+    let objKeys;
+    let filter;
 
     if (typeof options.filter === 'function') {
         filter = options.filter;
@@ -163,13 +161,13 @@ module.exports = function (object, opts) {
         objKeys = filter;
     }
 
-    var keys = [];
+    let keys = [];
 
     if (typeof obj !== 'object' || obj === null) {
         return '';
     }
 
-    var arrayFormat;
+    let arrayFormat;
     if (options.arrayFormat in arrayPrefixGenerators) {
         arrayFormat = options.arrayFormat;
     } else if ('indices' in options) {
@@ -178,7 +176,7 @@ module.exports = function (object, opts) {
         arrayFormat = 'indices';
     }
 
-    var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
+    const generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
 
     if (!objKeys) {
         objKeys = Object.keys(obj);
@@ -188,8 +186,8 @@ module.exports = function (object, opts) {
         objKeys.sort(sort);
     }
 
-    for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
+    for (let i = 0; i < objKeys.length; ++i) {
+        const key = objKeys[i];
 
         if (skipNulls && obj[key] === null) {
             continue;
@@ -212,18 +210,18 @@ module.exports = function (object, opts) {
         ));
     }
 
-    var joined = keys.join(delimiter);
-    var prefix = options.addQueryPrefix === true ? '?' : '';
+    const joined = keys.join(delimiter);
+    let prefix = options.addQueryPrefix === true ? '?' : '';
 
     if (options.charsetSentinel) {
         if (charset === 'iso-8859-1') {
             // encodeURIComponent('&#10003;'), the "numeric entity" representation of a checkmark
             prefix += 'utf8=%26%2310003%3B&';
         } else {
-            // encodeURIComponent('✓')
+            // encodeURIComponent('ÃÂ¢ÃÂÃÂ')
             prefix += 'utf8=%E2%9C%93&';
         }
     }
 
     return joined.length > 0 ? prefix + joined : '';
-};
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,27 +1,25 @@
-'use strict';
+const has = Object.prototype.hasOwnProperty;
 
-var has = Object.prototype.hasOwnProperty;
-
-var hexTable = (function () {
-    var array = [];
-    for (var i = 0; i < 256; ++i) {
+const hexTable = (function () {
+    const array = [];
+    for (let i = 0; i < 256; ++i) {
         array.push('%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase());
     }
 
     return array;
 }());
 
-var compactQueue = function compactQueue(queue) {
-    var obj;
+const compactQueue = function compactQueue(queue) {
+    let obj;
 
     while (queue.length) {
-        var item = queue.pop();
+        const item = queue.pop();
         obj = item.obj[item.prop];
 
         if (Array.isArray(obj)) {
-            var compacted = [];
+            const compacted = [];
 
-            for (var j = 0; j < obj.length; ++j) {
+            for (let j = 0; j < obj.length; ++j) {
                 if (typeof obj[j] !== 'undefined') {
                     compacted.push(obj[j]);
                 }
@@ -34,9 +32,9 @@ var compactQueue = function compactQueue(queue) {
     return obj;
 };
 
-var arrayToObject = function arrayToObject(source, options) {
-    var obj = options && options.plainObjects ? Object.create(null) : {};
-    for (var i = 0; i < source.length; ++i) {
+export const arrayToObject = function arrayToObject(source, options) {
+    const obj = options && options.plainObjects ? Object.create(null) : {};
+    for (let i = 0; i < source.length; ++i) {
         if (typeof source[i] !== 'undefined') {
             obj[i] = source[i];
         }
@@ -45,7 +43,7 @@ var arrayToObject = function arrayToObject(source, options) {
     return obj;
 };
 
-var merge = function merge(target, source, options) {
+export const merge = function merge(target, source, options) {
     if (!source) {
         return target;
     }
@@ -68,7 +66,7 @@ var merge = function merge(target, source, options) {
         return [target].concat(source);
     }
 
-    var mergeTarget = target;
+    let mergeTarget = target;
     if (Array.isArray(target) && !Array.isArray(source)) {
         mergeTarget = arrayToObject(target, options);
     }
@@ -89,7 +87,7 @@ var merge = function merge(target, source, options) {
     }
 
     return Object.keys(source).reduce(function (acc, key) {
-        var value = source[key];
+        const value = source[key];
 
         if (has.call(acc, key)) {
             acc[key] = merge(acc[key], value, options);
@@ -100,15 +98,15 @@ var merge = function merge(target, source, options) {
     }, mergeTarget);
 };
 
-var assign = function assignSingleSource(target, source) {
+export const assign = function assign(target, source) {
     return Object.keys(source).reduce(function (acc, key) {
         acc[key] = source[key];
         return acc;
     }, target);
 };
 
-var decode = function (str, decoder, charset) {
-    var strWithoutPlus = str.replace(/\+/g, ' ');
+export const decode = function decode(str, decoder, charset) {
+    const strWithoutPlus = str.replace(/\+/g, ' ');
     if (charset === 'iso-8859-1') {
         // unescape never throws, no try...catch needed:
         return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
@@ -121,14 +119,14 @@ var decode = function (str, decoder, charset) {
     }
 };
 
-var encode = function encode(str, defaultEncoder, charset) {
+export const encode = function encode(str, defaultEncoder, charset) {
     // This code was originally written by Brian White (mscdex) for the io.js core querystring library.
     // It has been adapted here for stricter adherence to RFC 3986
     if (str.length === 0) {
         return str;
     }
 
-    var string = typeof str === 'string' ? str : String(str);
+    const string = typeof str === 'string' ? str : String(str);
 
     if (charset === 'iso-8859-1') {
         return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
@@ -136,9 +134,9 @@ var encode = function encode(str, defaultEncoder, charset) {
         });
     }
 
-    var out = '';
-    for (var i = 0; i < string.length; ++i) {
-        var c = string.charCodeAt(i);
+    let out = '';
+    for (let i = 0; i < string.length; ++i) {
+        let c = string.charCodeAt(i);
 
         if (
             c === 0x2D // -
@@ -179,18 +177,18 @@ var encode = function encode(str, defaultEncoder, charset) {
     return out;
 };
 
-var compact = function compact(value) {
-    var queue = [{ obj: { o: value }, prop: 'o' }];
-    var refs = [];
+export const compact = function compact(value) {
+    const queue = [{ obj: { o: value }, prop: 'o' }];
+    const refs = [];
 
-    for (var i = 0; i < queue.length; ++i) {
-        var item = queue[i];
-        var obj = item.obj[item.prop];
+    for (let i = 0; i < queue.length; ++i) {
+        const item = queue[i];
+        const obj = item.obj[item.prop];
 
-        var keys = Object.keys(obj);
-        for (var j = 0; j < keys.length; ++j) {
-            var key = keys[j];
-            var val = obj[key];
+        const keys = Object.keys(obj);
+        for (let j = 0; j < keys.length; ++j) {
+            const key = keys[j];
+            const val = obj[key];
             if (typeof val === 'object' && val !== null && refs.indexOf(val) === -1) {
                 queue.push({ obj: obj, prop: key });
                 refs.push(val);
@@ -201,25 +199,14 @@ var compact = function compact(value) {
     return compactQueue(queue);
 };
 
-var isRegExp = function isRegExp(obj) {
+export const isRegExp = function isRegExp(obj) {
     return Object.prototype.toString.call(obj) === '[object RegExp]';
 };
 
-var isBuffer = function isBuffer(obj) {
+export const isBuffer = function isBuffer(obj) {
     if (obj === null || typeof obj === 'undefined') {
         return false;
     }
 
     return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
-};
-
-module.exports = {
-    arrayToObject: arrayToObject,
-    assign: assign,
-    compact: compact,
-    decode: decode,
-    encode: encode,
-    isBuffer: isBuffer,
-    isRegExp: isRegExp,
-    merge: merge
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "type": "git",
         "url": "https://github.com/ljharb/qs.git"
     },
-    "main": "lib/index.js",
+    "main": "lib/cjs/index.js",
+    "module": "lib/index.js",
     "contributors": [
         {
             "name": "Jordan Harband",
@@ -24,8 +25,10 @@
     },
     "dependencies": {},
     "devDependencies": {
+        "@babel/cli": "^7.0.0-rc.4",
+        "@babel/core": "^7.0.0-rc.4",
+        "@babel/preset-env": "^7.0.0-rc.4",
         "@ljharb/eslint-config": "^12.2.1",
-        "browserify": "^16.2.0",
         "covert": "^1.1.0",
         "editorconfig-tools": "^0.1.1",
         "eslint": "^4.19.1",
@@ -33,11 +36,13 @@
         "iconv-lite": "^0.4.21",
         "mkdirp": "^0.5.1",
         "qs-iconv": "^1.0.4",
+        "rollup": "^0.65.0",
         "safe-publish-latest": "^1.1.1",
         "safer-buffer": "^2.1.2",
         "tape": "^4.9.0"
     },
     "scripts": {
+        "build": "babel lib --out-dir lib/cjs/",
         "prepublish": "safe-publish-latest && npm run dist",
         "pretest": "npm run --silent readme && npm run --silent lint",
         "test": "npm run --silent coverage",
@@ -46,7 +51,7 @@
         "postlint": "editorconfig-tools check * lib/* test/*",
         "lint": "eslint lib/*.js test/*.js",
         "coverage": "covert test",
-        "dist": "mkdirp dist && browserify --standalone Qs lib/index.js > dist/qs.js"
+        "dist": "npm run build && rollup -c"
     },
     "license": "BSD-3-Clause"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,8 @@
+export default {
+    input: 'lib/index.js',
+    output: {
+        format: 'umd',
+        file: 'dist/qs.js',
+        name: 'Qs'
+    }
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,4 +1,8 @@
 {
+    "parserOptions": {
+        "ecmaVersion": 5,
+        "sourceType": "script"
+    },
     "rules": {
 		"array-bracket-newline": 0,
 		"array-element-newline": 0,

--- a/test/parse.js
+++ b/test/parse.js
@@ -2,7 +2,7 @@
 
 var test = require('tape');
 var qs = require('../');
-var utils = require('../lib/utils');
+var utils = require('../lib/cjs/utils');
 var iconv = require('iconv-lite');
 var SaferBuffer = require('safer-buffer').Buffer;
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -2,7 +2,7 @@
 
 var test = require('tape');
 var qs = require('../');
-var utils = require('../lib/utils');
+var utils = require('../lib/cjs/utils');
 var iconv = require('iconv-lite');
 var SaferBuffer = require('safer-buffer').Buffer;
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tape');
-var utils = require('../lib/utils');
+var utils = require('../lib/cjs/utils');
 
 test('merge()', function (t) {
     t.deepEqual(utils.merge({ a: 'b' }, { a: 'c' }), { a: ['b', 'c'] }, 'merges two objects with the same key');


### PR DESCRIPTION
All major browsers now support ES modules natively, so it would be extremely useful to have qs be built in such a way it can be used with them.

Here's what I did:

* Rewrote the original sources to be ES modules (in `lib/`)
* Replaced browserify with rollup (which outputs a UMD bundle from the ESM sources to `dist/`)
* Added babel to transpile the ESM sources to CJS modules (in `lib/cjs`, added to gitignore)
* Added `module` to package.json so third-party tools can detect where the ESM sources live at
* Changed `main` to point at the transpiled CJS sources so node still works (`lib/cjs/index.js`)
* Changed all occurrences of `var` to `let` or `const` as appropriate

I left the tests as commonjs sources (they do not get transpiled) mostly so i could ensure the cjs output worked the same way as the original sources before this PR.

I tested this in a browser:

```html
<script type="module">
import * as qs from './node_modules/qs/lib/index.js';
qs.parse('a%5Bb%5D=c');
</script>
```

and it works fine.

What needs extra thought:

* Do the CJS sources really belong in `lib/cjs`? is there a better place? maybe have esm in `src/` and cjs in `lib/`?
* babel-cli won't work in old node versions afaik so CI will fail in those

---

Is this something you'd be interested in @ljharb? It would probably mean a major version bump (or would it? could get away with minor if all my export changes match up?).

If its not something you think you'll ever be interested in or prepared to merge, I'm happy to throw away the PR but it would be useful to have such native browser support.

Thanks!

cc @ljharb 