### PR TITLE
add comma as an arrayFormat option

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ var arraysOfObjects = qs.parse('a[][b]=c');
 assert.deepEqual(arraysOfObjects, { a: [{ b: 'c' }] });
 ```
 
+Some people use comma to join array, **qs** can parse it:
+```javascript
+var arraysOfObjects = qs.parse('a=b,c', { comma: true })
+assert.deepEqual(arraysOfObjects, { a: ['b', 'c'] })
+```
+(_this cannot convert nested objects, such as `a={b:1},{c:d}`_)
+
 ### Stringifying
 
 [](#preventEval)
@@ -348,6 +355,8 @@ qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'brackets' })
 // 'a[]=b&a[]=c'
 qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'repeat' })
 // 'a=b&a=c'
+qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'comma' })
+// 'a=b,c'
 ```
 
 When objects are stringified, by default they use bracket notation:

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,6 +10,7 @@ var defaults = {
     arrayLimit: 20,
     charset: 'utf-8',
     charsetSentinel: false,
+    comma: false,
     decoder: utils.decode,
     delimiter: '&',
     depth: 5,
@@ -81,6 +82,11 @@ var parseValues = function parseQueryStringValues(str, options) {
         if (val && options.interpretNumericEntities && charset === 'iso-8859-1') {
             val = interpretNumericEntities(val);
         }
+
+        if (val && options.comma && val.indexOf(',') > -1) {
+            val = val.split(',');
+        }
+
         if (has.call(obj, key)) {
             obj[key] = utils.combine(obj[key], val);
         } else {
@@ -200,6 +206,7 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         arrayLimit: typeof opts.arrayLimit === 'number' ? opts.arrayLimit : defaults.arrayLimit,
         charset: charset,
         charsetSentinel: typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
+        comma: typeof opts.comma === 'boolean' ? opts.comma : defaults.comma,
         decoder: typeof opts.decoder === 'function' ? opts.decoder : defaults.decoder,
         delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
         depth: typeof opts.depth === 'number' ? opts.depth : defaults.depth,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -7,6 +7,7 @@ var arrayPrefixGenerators = {
     brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
         return prefix + '[]';
     },
+    comma: 'comma',
     indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
         return prefix + '[' + key + ']';
     },
@@ -62,6 +63,8 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
         obj = filter(prefix, obj);
     } else if (obj instanceof Date) {
         obj = serializeDate(obj);
+    } else if (generateArrayPrefix === 'comma' && isArray(obj)) {
+        obj = obj.join(',');
     }
 
     if (obj === null) {
@@ -104,7 +107,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
         if (isArray(obj)) {
             pushToArray(values, stringify(
                 obj[key],
-                generateArrayPrefix(prefix, key),
+                typeof generateArrayPrefix === 'function' ? generateArrayPrefix(prefix, key) : prefix,
                 generateArrayPrefix,
                 strictNullHandling,
                 skipNulls,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -87,7 +87,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
     }
 
     var objKeys;
-    if (Array.isArray(filter)) {
+    if (isArray(filter)) {
         objKeys = filter;
     } else {
         var keys = Object.keys(obj);
@@ -101,7 +101,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
             continue;
         }
 
-        if (Array.isArray(obj)) {
+        if (isArray(obj)) {
             pushToArray(values, stringify(
                 obj[key],
                 generateArrayPrefix(prefix, key),
@@ -195,7 +195,7 @@ module.exports = function (object, opts) {
     if (typeof options.filter === 'function') {
         filter = options.filter;
         obj = filter('', obj);
-    } else if (Array.isArray(options.filter)) {
+    } else if (isArray(options.filter)) {
         filter = options.filter;
         objKeys = filter;
     }

--- a/test/parse.js
+++ b/test/parse.js
@@ -347,6 +347,15 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('parses string with comma as array divider', function (st) {
+        st.deepEqual(qs.parse('foo=bar,tee', { comma: true }), { foo: ['bar', 'tee'] });
+        st.deepEqual(qs.parse('foo[bar]=coffee,tee', { comma: true }), { foo: { bar: ['coffee', 'tee'] } });
+        st.deepEqual(qs.parse('foo=', { comma: true }), { foo: '' });
+        st.deepEqual(qs.parse('foo', { comma: true }), { foo: '' });
+        st.deepEqual(qs.parse('foo', { comma: true, strictNullHandling: true }), { foo: null });
+        st.end();
+    });
+
     t.test('parses an object in dot notation', function (st) {
         var input = {
             'user.name': { 'pop[bob]': 3 },

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -19,6 +19,15 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('stringifies falsy values', function (st) {
+        st.equal(qs.stringify(undefined), '');
+        st.equal(qs.stringify(null), '');
+        st.equal(qs.stringify(null, { strictNullHandling: true }), '');
+        st.equal(qs.stringify(false), '');
+        st.equal(qs.stringify(0), '');
+        st.end();
+    });
+
     t.test('adds query prefix', function (st) {
         st.equal(qs.stringify({ a: 'b' }, { addQueryPrefix: true }), '?a=b');
         st.end();
@@ -26,6 +35,13 @@ test('stringify()', function (t) {
 
     t.test('with query prefix, outputs blank string given an empty object', function (st) {
         st.equal(qs.stringify({}, { addQueryPrefix: true }), '');
+        st.end();
+    });
+
+    t.test('stringifies nested falsy values', function (st) {
+        st.equal(qs.stringify({ a: { b: { c: null } } }), 'a%5Bb%5D%5Bc%5D=');
+        st.equal(qs.stringify({ a: { b: { c: null } } }, { strictNullHandling: true }), 'a%5Bb%5D%5Bc%5D');
+        st.equal(qs.stringify({ a: { b: { c: false } } }), 'a%5Bb%5D%5Bc%5D=false');
         st.end();
     });
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -69,6 +69,11 @@ test('stringify()', function (t) {
             'brackets => brackets'
         );
         st.equal(
+            qs.stringify({ a: ['b', 'c', 'd'] }, { arrayFormat: 'comma' }),
+            'a=b%2Cc%2Cd',
+            'comma => comma'
+        );
+        st.equal(
             qs.stringify({ a: ['b', 'c', 'd'] }),
             'a%5B0%5D=b&a%5B1%5D=c&a%5B2%5D=d',
             'default => indices'
@@ -94,6 +99,7 @@ test('stringify()', function (t) {
     t.test('stringifies a nested array value', function (st) {
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'indices' }), 'a%5Bb%5D%5B0%5D=c&a%5Bb%5D%5B1%5D=d');
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'brackets' }), 'a%5Bb%5D%5B%5D=c&a%5Bb%5D%5B%5D=d');
+        st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'comma' }), 'a%5Bb%5D=c%2Cd'); // a[b]=c,d
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }), 'a%5Bb%5D%5B0%5D=c&a%5Bb%5D%5B1%5D=d');
         st.end();
     });
@@ -118,6 +124,14 @@ test('stringify()', function (t) {
         st.equal(
             qs.stringify(
                 { a: { b: ['c', 'd'] } },
+                { allowDots: true, encode: false, arrayFormat: 'comma' }
+            ),
+            'a.b=c,d',
+            'comma: stringifies with dots + comma'
+        );
+        st.equal(
+            qs.stringify(
+                { a: { b: ['c', 'd'] } },
                 { allowDots: true, encode: false }
             ),
             'a.b[0]=c&a.b[1]=d',
@@ -129,12 +143,12 @@ test('stringify()', function (t) {
     t.test('stringifies an object inside an array', function (st) {
         st.equal(
             qs.stringify({ a: [{ b: 'c' }] }, { arrayFormat: 'indices' }),
-            'a%5B0%5D%5Bb%5D=c',
+            'a%5B0%5D%5Bb%5D=c', // a[0][b]=c
             'indices => brackets'
         );
         st.equal(
             qs.stringify({ a: [{ b: 'c' }] }, { arrayFormat: 'brackets' }),
-            'a%5B%5D%5Bb%5D=c',
+            'a%5B%5D%5Bb%5D=c', // a[][b]=c
             'brackets => brackets'
         );
         st.equal(


### PR DESCRIPTION
It is a common feature request to parse array in 'comma' format, like #219 .

Simple allow we passed a function to arrayFormat, as #275 described, could not work, as 'comma' actually alter the left-side of equation, in a way that join the values of array rather than list them with well-structured key.  

In turn I create this new PR as an alternative way to solve it. However, it is still suffered some designed issue.

It would be hard to determine that how we represent complex array, such as `a=[{b: 'c'}]` in comma format. I simply use `JSON.stringify` to deal with inner objects, but I believe that there should be more common acknowledge to discuss about it.

Fortunately, most use-case of comma format would treat the values of array as a plain string, in turn there would be no problem with my approach. 

Further discussion would be welcomed. 
