### PR TITLE
Allow `strictNullHandling` to work when using a custom filter

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -55,7 +55,9 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
         obj = filter(prefix, obj);
     } else if (obj instanceof Date) {
         obj = serializeDate(obj);
-    } else if (obj === null) {
+    }
+
+    if (obj === null) {
         if (strictNullHandling) {
             return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset) : prefix;
         }

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -625,5 +625,25 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('strictNullHandling works with custom filter', function (st) {
+        var filter = function (prefix, value) {
+            return value;
+        };
+
+        var options = { strictNullHandling: true, filter: filter };
+        st.equal(qs.stringify({ key: null }, options), 'key');
+        st.end();
+    });
+
+    t.test('strictNullHandling works with null serializeDate', function (st) {
+        var serializeDate = function () {
+            return null;
+        };
+        var options = { strictNullHandling: true, serializeDate: serializeDate };
+        var date = new Date();
+        st.equal(qs.stringify({ key: date }, options), 'key');
+        st.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Fixes https://github.com/ljharb/qs/issues/278