### PR TITLE
Introduces new `mapKeys` option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,11 +11,11 @@
         "indent": [2, 4],
         "max-lines-per-function": [2, { "max": 150 }],
         "max-params": [2, 14],
-        "max-statements": [2, 52],
+        "max-statements": [2, 53],
         "multiline-comment-style": 0,
         "no-continue": 1,
         "no-magic-numbers": 0,
         "no-restricted-syntax": [2, "BreakStatement", "DebuggerStatement", "ForInStatement", "LabeledStatement", "WithStatement"],
-        "operator-linebreak": [2, "before"],
+        "operator-linebreak": [2, "before"]
     }
 }

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ assert.deepEqual(detectedAsIso8859_1, { a: '☺' });
 It also works when the charset has been detected in `charsetSentinel`
 mode.
 
+In addition, you can transform parsed keys after decoding with `mapKeys`:
+
+```javascript
+assert.deepEqual(
+    qs.parse('aField=7', { mapKeys: function (k) { return k === 'aField' ? 'a' : k; } }),
+    { a: 7 }
+);
+```
+
 ### Parsing Arrays
 
 **qs** can also parse arrays using a similar `[]` notation:
@@ -407,6 +416,15 @@ assert.equal(
     qs.stringify({ a: date }, { serializeDate: function (d) { return d.getTime(); } }),
     'a=7'
 );
+```
+
+In addition, you can transform keys entirely without writing a custom encoder using `mapKeys`:
+
+```javascript
+assert.equal(
+    qs.stringify({ a__rename: 7 }, { mapKeys: function(k) { return k === 'a__rename' ? 'a' : k; } }),
+    'a=7'
+)
 ```
 
 You may use the `sort` option to affect the order of parameter keys:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ In addition, you can transform parsed keys after decoding with `mapKeys`:
 ```javascript
 assert.deepEqual(
     qs.parse('aField=7', { mapKeys: function (k) { return k === 'aField' ? 'a' : k; } }),
-    { a: 7 }
+    { a: '7' }
 );
 ```
 

--- a/dist/qs.js
+++ b/dist/qs.js
@@ -578,7 +578,7 @@ var merge = function merge(target, source, options) {
     if (Array.isArray(target) && Array.isArray(source)) {
         source.forEach(function (item, i) {
             if (has.call(target, i)) {
-                if (target[i] && typeof target[i] === 'object') {
+                if (target[i] && typeof target[i] === 'object' && item && typeof item === 'object') {
                     target[i] = merge(target[i], item, options);
                 } else {
                     target.push(item);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -15,6 +15,9 @@ var defaults = {
     depth: 5,
     ignoreQueryPrefix: false,
     interpretNumericEntities: false,
+    mapKeys: function mapKeys(key) {
+        return key;
+    },
     parameterLimit: 1000,
     parseArrays: true,
     plainObjects: false,
@@ -77,6 +80,8 @@ var parseValues = function parseQueryStringValues(str, options) {
             key = options.decoder(part.slice(0, pos), defaults.decoder, charset);
             val = options.decoder(part.slice(pos + 1), defaults.decoder, charset);
         }
+
+        key = options.mapKeys(key);
 
         if (val && options.interpretNumericEntities && charset === 'iso-8859-1') {
             val = interpretNumericEntities(val);
@@ -193,6 +198,7 @@ module.exports = function (str, opts) {
     options.arrayLimit = typeof options.arrayLimit === 'number' ? options.arrayLimit : defaults.arrayLimit;
     options.parseArrays = options.parseArrays !== false;
     options.decoder = typeof options.decoder === 'function' ? options.decoder : defaults.decoder;
+    options.mapKeys = typeof options.mapKeys === 'function' ? options.mapKeys : defaults.mapKeys;
     options.allowDots = typeof options.allowDots === 'undefined' ? defaults.allowDots : !!options.allowDots;
     options.plainObjects = typeof options.plainObjects === 'boolean' ? options.plainObjects : defaults.plainObjects;
     options.allowPrototypes = typeof options.allowPrototypes === 'boolean' ? options.allowPrototypes : defaults.allowPrototypes;

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -34,6 +34,9 @@ var defaults = {
     encodeValuesOnly: false,
     // deprecated
     indices: false,
+    mapKeys: function mapKeys(key) {
+        return key;
+    },
     serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
         return toISO.call(date);
     },
@@ -51,6 +54,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
     filter,
     sort,
     allowDots,
+    mapKeys,
     serializeDate,
     formatter,
     encodeValuesOnly,
@@ -74,7 +78,8 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
         if (encoder) {
             var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset);
-            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset))];
+            var transformedKey = mapKeys(keyValue);
+            return [formatter(transformedKey) + '=' + formatter(encoder(obj, defaults.encoder, charset))];
         }
         return [formatter(prefix) + '=' + formatter(String(obj))];
     }
@@ -87,9 +92,9 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
 
     var objKeys;
     if (Array.isArray(filter)) {
-        objKeys = filter;
+        objKeys = filter.map(mapKeys);
     } else {
-        var keys = Object.keys(obj);
+        var keys = Object.keys(obj).map(mapKeys);
         objKeys = sort ? keys.sort(sort) : keys;
     }
 
@@ -111,6 +116,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
                 filter,
                 sort,
                 allowDots,
+                mapKeys,
                 serializeDate,
                 formatter,
                 encodeValuesOnly,
@@ -127,6 +133,7 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
                 filter,
                 sort,
                 allowDots,
+                mapKeys,
                 serializeDate,
                 formatter,
                 encodeValuesOnly,
@@ -153,6 +160,7 @@ module.exports = function (object, opts) {
     var encoder = typeof options.encoder === 'function' ? options.encoder : defaults.encoder;
     var sort = typeof options.sort === 'function' ? options.sort : null;
     var allowDots = typeof options.allowDots === 'undefined' ? defaults.allowDots : !!options.allowDots;
+    var mapKeys = typeof options.mapKeys === 'function' ? options.mapKeys : defaults.mapKeys;
     var serializeDate = typeof options.serializeDate === 'function' ? options.serializeDate : defaults.serializeDate;
     var encodeValuesOnly = typeof options.encodeValuesOnly === 'boolean' ? options.encodeValuesOnly : defaults.encodeValuesOnly;
     var charset = options.charset || defaults.charset;
@@ -218,6 +226,7 @@ module.exports = function (object, opts) {
             filter,
             sort,
             allowDots,
+            mapKeys,
             serializeDate,
             formatter,
             encodeValuesOnly,

--- a/test/parse.js
+++ b/test/parse.js
@@ -154,6 +154,22 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('mapKeys option', function (st) {
+        st.deepEqual(
+            qs.parse('a=7'),
+            { a: 7 },
+            'default key is \'a\''
+        );
+        st.deepEqual(
+            qs.parse(
+                'aField=7', // eslint-disable-line camelcase
+                { mapKeys: function (k) { return k === 'aField' ? 'a' : k; } }
+            ),
+            { a: 7 },
+            'custom mapKeys function called'
+        );
+    });
+
     t.test('correctly prunes undefined values when converting an array to an object', function (st) {
         st.deepEqual(qs.parse('a[2]=b&a[99999999]=c'), { a: { 2: 'b', 99999999: 'c' } });
         st.end();

--- a/test/parse.js
+++ b/test/parse.js
@@ -157,7 +157,7 @@ test('parse()', function (t) {
     t.test('mapKeys option', function (st) {
         st.deepEqual(
             qs.parse('a=7'),
-            { a: 7 },
+            { a: '7' },
             'default key is \'a\''
         );
         st.deepEqual(
@@ -165,7 +165,7 @@ test('parse()', function (t) {
                 'aField=7', // eslint-disable-line camelcase
                 { mapKeys: function (k) { return k === 'aField' ? 'a' : k; } }
             ),
-            { a: 7 },
+            { a: '7' },
             'custom mapKeys function called'
         );
     });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -493,6 +493,22 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('mapKeys option', function (st) {
+        st.equal(
+            qs.stringify({ a: 7 }),
+            'a=7',
+            'default key is \'a\''
+        );
+        st.equal(
+            qs.stringify(
+                { a__rename: 7 }, // eslint-disable-line camelcase
+                { mapKeys: function (k) { return k === 'a__rename' ? 'a' : k; } }
+            ),
+            'a=7',
+            'custom mapKeys function called'
+        );
+    });
+
     t.test('serializeDate option', function (st) {
         var date = new Date();
         st.equal(


### PR DESCRIPTION
Fixes #291

This patch introduces a new option for the `stringify` and `parse`
functions to apply a transformation per key before encoding/after
decoding. 

This is still a WIP as I can't seem to get the test suite
passing locally. Any and all feedback would be appreciated!