### PR TITLE
Fixed `Qs` -> `qs` in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "postlint": "editorconfig-tools check * lib/* test/*",
         "lint": "eslint lib/*.js test/*.js",
         "coverage": "covert test",
-        "dist": "mkdirp dist && browserify --standalone Qs lib/index.js > dist/qs.js"
+        "dist": "mkdirp dist && browserify --standalone qs lib/index.js > dist/qs.js"
     },
     "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
The library does not export a default constructor, so we should not export to `window` a variable `Qs`, it should be `qs` instead, and thus will match the Node API.