### PR TITLE
[New] `parse`: add `allowSparse` option for collapsing arrays with missing indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ var noSparse = qs.parse('a[1]=b&a[15]=c');
 assert.deepEqual(noSparse, { a: ['b', 'c'] });
 ```
 
+You may also use `allowSparse` option to parse sparse arrays:
+
+```javascript
+var sparseArray = qs.parse('a[1]=2&a[3]=5', { allowSparse: true });
+assert.deepEqual(sparseArray, { a: [, '2', , '5'] });
+```
+
 Note that an empty string is also a value, and will be preserved:
 
 ```javascript

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -8,6 +8,7 @@ var isArray = Array.isArray;
 var defaults = {
     allowDots: false,
     allowPrototypes: false,
+    allowSparse: false,
     arrayLimit: 20,
     charset: 'utf-8',
     charsetSentinel: false,
@@ -217,6 +218,7 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
     return {
         allowDots: typeof opts.allowDots === 'undefined' ? defaults.allowDots : !!opts.allowDots,
         allowPrototypes: typeof opts.allowPrototypes === 'boolean' ? opts.allowPrototypes : defaults.allowPrototypes,
+        allowSparse: typeof opts.allowSparse === 'boolean' ? opts.allowSparse : defaults.allowSparse,
         arrayLimit: typeof opts.arrayLimit === 'number' ? opts.arrayLimit : defaults.arrayLimit,
         charset: charset,
         charsetSentinel: typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
@@ -251,6 +253,10 @@ module.exports = function (str, opts) {
         var key = keys[i];
         var newObj = parseKeys(key, tempObj[key], options, typeof str === 'string');
         obj = utils.merge(obj, newObj, options);
+    }
+
+    if (options.allowSparse === true) {
+        return obj;
     }
 
     return utils.compact(obj);

--- a/test/parse.js
+++ b/test/parse.js
@@ -269,6 +269,15 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('parses sparse arrays', function (st) {
+        /* eslint no-sparse-arrays: 0 */
+        st.deepEqual(qs.parse('a[4]=1&a[1]=2', { allowSparse: true }), { a: [, '2', , , '1'] });
+        st.deepEqual(qs.parse('a[1][b][2][c]=1', { allowSparse: true }), { a: [, { b: [, , { c: '1' }] }] });
+        st.deepEqual(qs.parse('a[1][2][3][c]=1', { allowSparse: true }), { a: [, [, , [, , , { c: '1' }]]] });
+        st.deepEqual(qs.parse('a[1][2][3][c][1]=1', { allowSparse: true }), { a: [, [, , [, , , { c: [, '1'] }]]] });
+        st.end();
+    });
+
     t.test('parses semi-parsed strings', function (st) {
         st.deepEqual(qs.parse({ 'a[b]': 'c' }), { a: { b: 'c' } });
         st.deepEqual(qs.parse({ 'a[b]': 'c', 'a[d]': 'e' }), { a: { b: 'c', d: 'e' } });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -789,5 +789,15 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('stringifies sparse arrays', function (st) {
+        /* eslint no-sparse-arrays: 0 */
+        st.equal(qs.stringify({ a: [, '2', , , '1'] }, { encodeValuesOnly: true }), 'a[1]=2&a[4]=1');
+        st.equal(qs.stringify({ a: [, { b: [, , { c: '1' }] }] }, { encodeValuesOnly: true }), 'a[1][b][2][c]=1');
+        st.equal(qs.stringify({ a: [, [, , [, , , { c: '1' }]]] }, { encodeValuesOnly: true }), 'a[1][2][3][c]=1');
+        st.equal(qs.stringify({ a: [, [, , [, , , { c: [, '1'] }]]] }, { encodeValuesOnly: true }), 'a[1][2][3][c][1]=1');
+
+        st.end();
+    });
+
     t.end();
 });


### PR DESCRIPTION
Fixes #181 