### PR TITLE
change default arrayFormat to repeat

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -226,7 +226,7 @@ module.exports = function (object, opts) {
     } else if (opts && 'indices' in opts) {
         arrayFormat = opts.indices ? 'indices' : 'repeat';
     } else {
-        arrayFormat = 'indices';
+        arrayFormat = 'repeat';
     }
 
     var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];


### PR DESCRIPTION
 This change is required so that the keys are not the default.

PS.
before commit
qs.stringify({ id: ['a', 'b'] }); => id%5B0%5D=a&id%5B1%5D=b (id[0]=a&id[1]=b)

after commit
qs.stringify({ id: ['a', 'b'] }); => id=a&id=b