### PR TITLE
Fix `depth: 0`, add `depth: false`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -147,7 +147,7 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
 
     // Get the parent
 
-    var segment = brackets.exec(key);
+    var segment = options.depth > 0 && brackets.exec(key);
     var parent = segment ? key.slice(0, segment.index) : key;
 
     // Stash the parent if it exists
@@ -167,7 +167,7 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
     // Loop through children appending to the array until we hit depth
 
     var i = 0;
-    while ((segment = child.exec(key)) !== null && i < options.depth) {
+    while (options.depth > 0 && (segment = child.exec(key)) !== null && i < options.depth) {
         i += 1;
         if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
             if (!options.allowPrototypes) {
@@ -209,7 +209,8 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         comma: typeof opts.comma === 'boolean' ? opts.comma : defaults.comma,
         decoder: typeof opts.decoder === 'function' ? opts.decoder : defaults.decoder,
         delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
-        depth: typeof opts.depth === 'number' ? opts.depth : defaults.depth,
+        // eslint-disable-next-line no-implicit-coercion, no-extra-parens
+        depth: (typeof opts.depth === 'number' || opts.depth === false) ? +opts.depth : defaults.depth,
         ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
         interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
         parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,

--- a/test/parse.js
+++ b/test/parse.js
@@ -52,25 +52,13 @@ test('parse()', function (t) {
         st.end();
     });
 
-    t.test('current behavior with depth = 0', function (st) {
-        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: 0 }), { a: { '[0]': 'b', '[1]': 'c' } });
-        st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: 0 }), { a: { '[0][0]': 'b', '[0][1]': 'c', '[1]': 'd' }, e: '2' });
-        st.end();
-    });
-
-    t.test('uses original key when depth = 0', { skip: true, todo: true }, function (st) {
+    t.test('uses original key when depth = 0', function (st) {
         st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: 0 }), { 'a[0]': 'b', 'a[1]': 'c' });
         st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: 0 }), { 'a[0][0]': 'b', 'a[0][1]': 'c', 'a[1]': 'd', e: '2' });
         st.end();
     });
 
-    t.test('current behavior with depth = false', function (st) {
-        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: false }), { a: ['b', 'c'] });
-        st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: false }), { a: [['b', 'c'], 'd'], e: '2' });
-        st.end();
-    });
-
-    t.test('uses original key when depth = false', { skip: true, todo: true }, function (st) {
+    t.test('uses original key when depth = false', function (st) {
         st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: false }), { 'a[0]': 'b', 'a[1]': 'c' });
         st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: false }), { 'a[0][0]': 'b', 'a[0][1]': 'c', 'a[1]': 'd', e: '2' });
         st.end();

--- a/test/parse.js
+++ b/test/parse.js
@@ -52,6 +52,30 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('current behavior with depth = 0', function (st) {
+        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: 0 }), { a: { '[0]': 'b', '[1]': 'c' } });
+        st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: 0 }), { a: { '[0][0]': 'b', '[0][1]': 'c', '[1]': 'd' }, e: '2' });
+        st.end();
+    });
+
+    t.test('uses original key when depth = 0', { skip: true, todo: true }, function (st) {
+        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: 0 }), { 'a[0]': 'b', 'a[1]': 'c' });
+        st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: 0 }), { 'a[0][0]': 'b', 'a[0][1]': 'c', 'a[1]': 'd', e: '2' });
+        st.end();
+    });
+
+    t.test('current behavior with depth = false', function (st) {
+        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: false }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: false }), { a: [['b', 'c'], 'd'], e: '2' });
+        st.end();
+    });
+
+    t.test('uses original key when depth = false', { skip: true, todo: true }, function (st) {
+        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: false }), { 'a[0]': 'b', 'a[1]': 'c' });
+        st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: false }), { 'a[0][0]': 'b', 'a[0][1]': 'c', 'a[1]': 'd', e: '2' });
+        st.end();
+    });
+
     t.deepEqual(qs.parse('a=b&a=c'), { a: ['b', 'c'] }, 'parses a simple array');
 
     t.test('parses an explicit array', function (st) {


### PR DESCRIPTION
@ljharb Edit: this PR now adds tests for the current useless behavior of depth 0, and then fixes it. Fixes #261.

```
//当options.depth为空时,按&符进行分割
assert.deepEqual(qs.parse('ids[0]=1&ids[1]=2&ids[2]=3', { depth: 0 }), { 'ids[0]': 1, 'ids[1]': 2, 'ids[2]': 3 })
```
测试已经通过
我觉得这可以作为一个补充规则