### PR TITLE
arrayFormat for parse

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -34,31 +34,31 @@ test('parse()', function (t) {
 
     t.test('arrayFormat: brackets allows only explicit arrays', function (st) {
         st.deepEqual(qs.parse('a[]=b&a[]=c', { arrayFormat: 'brackets' }), { a: ['b', 'c'] });
-        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { arrayFormat: 'brackets' }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { arrayFormat: 'brackets' }), { 'a[0]': 'b', 'a[1]': 'c' });
         st.deepEqual(qs.parse('a=b,c', { arrayFormat: 'brackets' }), { a: 'b,c' });
-        st.deepEqual(qs.parse('a=b&a=c', { arrayFormat: 'brackets' }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a=b&a=c', { arrayFormat: 'brackets' }), { a: 'c' });
         st.end();
     });
 
     t.test('arrayFormat: indices allows only indexed arrays', function (st) {
-        st.deepEqual(qs.parse('a[]=b&a[]=c', { arrayFormat: 'indices' }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a[]=b&a[]=c', { arrayFormat: 'indices' }), { 'a[]': 'c' });
         st.deepEqual(qs.parse('a[0]=b&a[1]=c', { arrayFormat: 'indices' }), { a: ['b', 'c'] });
         st.deepEqual(qs.parse('a=b,c', { arrayFormat: 'indices' }), { a: 'b,c' });
-        st.deepEqual(qs.parse('a=b&a=c', { arrayFormat: 'indices' }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a=b&a=c', { arrayFormat: 'indices' }), { a: 'c' });
         st.end();
     });
 
     t.test('arrayFormat: comma allows only comma-separated arrays', function (st) {
-        st.deepEqual(qs.parse('a[]=b&a[]=c', { arrayFormat: 'comma' }), { a: ['b', 'c'] });
-        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { arrayFormat: 'comma' }), { a: ['b', 'c'] });
-        st.deepEqual(qs.parse('a=b,c', { arrayFormat: 'comma' }), { a: 'b,c' });
-        st.deepEqual(qs.parse('a=b&a=c', { arrayFormat: 'comma' }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a[]=b&a[]=c', { arrayFormat: 'comma' }), { 'a[]': 'c' });
+        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { arrayFormat: 'comma' }), { 'a[0]': 'b', 'a[1]': 'c' });
+        st.deepEqual(qs.parse('a=b,c', { arrayFormat: 'comma' }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a=b&a=c', { arrayFormat: 'comma' }), { a: 'c' });
         st.end();
     });
 
     t.test('arrayFormat: repeat allows only repeated values', function (st) {
-        st.deepEqual(qs.parse('a[]=b&a[]=c', { arrayFormat: 'repeat' }), { a: ['b', 'c'] });
-        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { arrayFormat: 'repeat' }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a[]=b&a[]=c', { arrayFormat: 'repeat' }), { 'a[]': 'c' });
+        st.deepEqual(qs.parse('a[0]=b&a[1]=c', { arrayFormat: 'repeat' }), { 'a[0]': 'b', 'a[1]': 'c' });
         st.deepEqual(qs.parse('a=b,c', { arrayFormat: 'repeat' }), { a: 'b,c' });
         st.deepEqual(qs.parse('a=b&a=c', { arrayFormat: 'repeat' }), { a: ['b', 'c'] });
         st.end();


### PR DESCRIPTION
added basic tests. without arrayFormat parse's behavior does not change

don't think we want to allow specifying several formats simultaneously?