### PR TITLE
[fix] comma option enabled value parsing to use strings only

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -83,7 +83,7 @@ var parseValues = function parseQueryStringValues(str, options) {
             val = interpretNumericEntities(val);
         }
 
-        if (val && options.comma && val.indexOf(',') > -1) {
+        if (val && typeof val === 'string' && options.comma && val.indexOf(',') > -1) {
             val = val.split(',');
         }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -400,6 +400,20 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('use number decoder, parses string that has one number with comma option enabled', function (st) {
+        var decoder = function (str, defaultDecoder, charset, type) {
+            if (!isNaN(Number(str))) {
+                return parseFloat(str);
+            }
+            return defaultDecoder(str, defaultDecoder, charset, type);
+        };
+
+        st.deepEqual(qs.parse('foo=1', { comma: true, decoder: decoder }), { foo: 1 });
+        st.deepEqual(qs.parse('foo=0', { comma: true, decoder: decoder }), { foo: 0 });
+
+        st.end();
+    });
+
     t.test('parses an object in dot notation', function (st) {
         var input = {
             'user.name': { 'pop[bob]': 3 },


### PR DESCRIPTION
in case of comma enabled .. parsing should check for strings only when using indexOf(',')

fixes: #328