### PR TITLE
Fix issue with parsing array from object

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -29,6 +29,14 @@ var interpretNumericEntities = function (str) {
     });
 };
 
+var parseArrayValue = function (val, options) {
+    if (val && typeof val === 'string' && options.comma && val.indexOf(',') > -1) {
+        return val.split(',');
+    }
+
+    return val;
+};
+
 // This is what browsers will submit when the ✓ character occurs in an
 // application/x-www-form-urlencoded body and the encoding of the page containing
 // the form is iso-8859-1, or when the submitted form has an accept-charset
@@ -84,9 +92,7 @@ var parseValues = function parseQueryStringValues(str, options) {
             val = interpretNumericEntities(val);
         }
 
-        if (val && typeof val === 'string' && options.comma && val.indexOf(',') > -1) {
-            val = val.split(',');
-        }
+        val = parseArrayValue(val, options);
 
         if (part.indexOf('[]=') > -1) {
             val = isArray(val) ? [val] : val;
@@ -103,7 +109,7 @@ var parseValues = function parseQueryStringValues(str, options) {
 };
 
 var parseObject = function (chain, val, options) {
-    var leaf = val;
+    var leaf = parseArrayValue(val, options);
 
     for (var i = chain.length - 1; i >= 0; --i) {
         var obj;

--- a/test/parse.js
+++ b/test/parse.js
@@ -400,6 +400,12 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('parses values with comma as array divider', function (st) {
+        st.deepEqual(qs.parse({ foo: 'bar,tee' }, { comma: false }), { foo: 'bar,tee' });
+        st.deepEqual(qs.parse({ foo: 'bar,tee' }, { comma: true }), { foo: ['bar', 'tee'] });
+        st.end();
+    });
+
     t.test('use number decoder, parses string that has one number with comma option enabled', function (st) {
         var decoder = function (str, defaultDecoder, charset, type) {
             if (!isNaN(Number(str))) {


### PR DESCRIPTION
Fixes issue with parsing array with `{comma: true}` option when query string is passed as an object.

Discussed in https://github.com/ljharb/qs/issues/357