### PR TITLE
Add support for stringifying space, pipe, and tab delimited arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- [New] Add support stringifying `space`, `pipe`, and `tab` delimited arrays (#363)
+
 ## **6.9.3**
 - [Fix] proper comma parsing of URL-encoded commas (#361)
 - [Fix] parses comma delimited array while having percent-encoded comma treated as normal text (#336)

--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'repeat' })
 // 'a=b&a=c'
 qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'comma' })
 // 'a=b,c'
+qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'space' })
+// 'a=b c'
+qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'pipe' })
+// 'a=b|c'
+qs.stringify({ a: ['b', 'c'] }, { arrayFormat: 'tab' })
+// 'a=b\tc'
 ```
 
 When objects are stringified, by default they use bracket notation:

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -12,9 +12,12 @@ var arrayPrefixGenerators = {
     indices: function indices(prefix, key) {
         return prefix + '[' + key + ']';
     },
+    pipe: 'pipe',
     repeat: function repeat(prefix) {
         return prefix;
-    }
+    },
+    space: 'space',
+    tab: 'tab'
 };
 
 var isArray = Array.isArray;
@@ -76,6 +79,12 @@ var stringify = function stringify(
         obj = serializeDate(obj);
     } else if (generateArrayPrefix === 'comma' && isArray(obj)) {
         obj = obj.join(',');
+    } else if (generateArrayPrefix === 'space' && isArray(obj)) {
+        obj = obj.join(' ');
+    } else if (generateArrayPrefix === 'pipe' && isArray(obj)) {
+        obj = obj.join('|');
+    } else if (generateArrayPrefix === 'tab' && isArray(obj)) {
+        obj = obj.join('\t');
     }
 
     if (obj === null) {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -109,6 +109,21 @@ test('stringify()', function (t) {
             'comma => comma'
         );
         st.equal(
+            qs.stringify({ a: ['b', 'c', 'd'] }, { arrayFormat: 'space' }),
+            'a=b%20c%20d',
+            'space => space'
+        );
+        st.equal(
+            qs.stringify({ a: ['b', 'c', 'd'] }, { arrayFormat: 'pipe' }),
+            'a=b%7Cc%7Cd',
+            'pipe => pipe'
+        );
+        st.equal(
+            qs.stringify({ a: ['b', 'c', 'd'] }, { arrayFormat: 'tab' }),
+            'a=b%09c%09d',
+            'tab => tab'
+        );
+        st.equal(
             qs.stringify({ a: ['b', 'c', 'd'] }),
             'a%5B0%5D=b&a%5B1%5D=c&a%5B2%5D=d',
             'default => indices'
@@ -135,6 +150,9 @@ test('stringify()', function (t) {
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'indices' }), 'a%5Bb%5D%5B0%5D=c&a%5Bb%5D%5B1%5D=d');
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'brackets' }), 'a%5Bb%5D%5B%5D=c&a%5Bb%5D%5B%5D=d');
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'comma' }), 'a%5Bb%5D=c%2Cd'); // a[b]=c,d
+        st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'space' }), 'a%5Bb%5D=c%20d'); // a[b]=c d
+        st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'pipe' }), 'a%5Bb%5D=c%7Cd'); // a[b]=c|d
+        st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { arrayFormat: 'tab' }), 'a%5Bb%5D=c%09d'); // a[b]=c\td
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }), 'a%5Bb%5D%5B0%5D=c&a%5Bb%5D%5B1%5D=d');
         st.end();
     });
@@ -163,6 +181,30 @@ test('stringify()', function (t) {
             ),
             'a.b=c,d',
             'comma: stringifies with dots + comma'
+        );
+        st.equal(
+            qs.stringify(
+                { a: { b: ['c', 'd'] } },
+                { allowDots: true, encode: false, arrayFormat: 'space' }
+            ),
+            'a.b=c d',
+            'space: stringifies with dots + space'
+        );
+        st.equal(
+            qs.stringify(
+                { a: { b: ['c', 'd'] } },
+                { allowDots: true, encode: false, arrayFormat: 'pipe' }
+            ),
+            'a.b=c|d',
+            'pipe: stringifies with dots + pipe'
+        );
+        st.equal(
+            qs.stringify(
+                { a: { b: ['c', 'd'] } },
+                { allowDots: true, encode: false, arrayFormat: 'tab' }
+            ),
+            'a.b=c\td',
+            'tab: stringifies with dots + tab'
         );
         st.equal(
             qs.stringify(


### PR DESCRIPTION
I use this library for stringifying query strings in an API client generated from an OpenAPI spec. As part of the OpenAPI specification, developers may specify that an array may be delimited with a `comma`, `space`, `pipe`, or `tab` character, as well as repeated or exploded. This commit adds support for stringifying arrays with the additional delimiter types.

README, CHANGELOG, test/, and dist/ have all been updated in this PR as well.