### PR TITLE
[meta] Add test and configuration files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,4 +15,14 @@ coverage/
 bower.json
 component.json
 .npmignore
-.github/workflows
+.github/workflows/
+.github/FUNDING.yml
+
+# tests
+test/
+
+# tooling configs
+.eslintrc
+.eslintignore
+.editorconfig
+.nycrc


### PR DESCRIPTION
I think most users don't need neither tests nor config files when they download a package. I'd also remove CHANGELOG.md, but npm won't let me do that.

Package size reduced by ~40% both packed and unpacked.

```diff
@@ -9,34 +9,26 @@ Detected non-install and non-publish: exiting.
 npm notice
 npm notice 📦  qs@6.9.6
 npm notice === Tarball Contents ===
-npm notice 520B   .editorconfig
-npm notice 16B    .eslintignore
-npm notice 1.0kB  .eslintrc
-npm notice 216B   .nycrc
 npm notice 476B   lib/formats.js
 npm notice 211B   lib/index.js
 npm notice 9.3kB  lib/parse.js
-npm notice 33.3kB test/parse.js
 npm notice 26.1kB dist/qs.js
 npm notice 8.4kB  lib/stringify.js
-npm notice 30.8kB test/stringify.js
 npm notice 6.8kB  lib/utils.js
-npm notice 5.1kB  test/utils.js
 npm notice 2.0kB  package.json
 npm notice 20.0kB CHANGELOG.md
 npm notice 1.6kB  LICENSE.md
 npm notice 19.8kB README.md
-npm notice 548B   .github/FUNDING.yml
 npm notice === Tarball Details ===
 npm notice name:          qs
 npm notice version:       6.9.6
 npm notice filename:      qs-6.9.6.tgz
-npm notice package size:  37.0 kB
-npm notice unpacked size: 168.4 kB
-npm notice shasum:        af29cab02a478195f2e423b84c167d9cd927bd21
-npm notice integrity:     sha512-qF2xgWi49vJRz[...]czs7/dQzToK6g==
-npm notice total files:   20
+npm notice package size:  20.6 kB
+npm notice unpacked size: 96.9 kB
+npm notice shasum:        ef5052808def8c8c09588a370dc814d40a7e8d80
+npm notice integrity:     sha512-LB4f8bQhvX4NT[...]QTl7Y0WesYX6A==
+npm notice total files:   12
 npm notice
 qs-6.9.6.tgz
```