### PR TITLE
Fixes the issue of stringify encoding comma(used to join array) even when `encodeValuesOnly = true`

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -19,6 +19,7 @@ var arrayPrefixGenerators = {
 };
 
 var isArray = Array.isArray;
+var split = String.prototype.split;
 var push = Array.prototype.push;
 var pushToArray = function (arr, valueOrArray) {
     push.apply(arr, isArray(valueOrArray) ? valueOrArray : [valueOrArray]);
@@ -102,6 +103,14 @@ var stringify = function stringify(
     if (isNonNullishPrimitive(obj) || utils.isBuffer(obj)) {
         if (encoder) {
             var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset, 'key', format);
+            if (generateArrayPrefix === 'comma' && encodeValuesOnly) {
+                var valuesArray = split.call(String(obj), ',');
+                var valuesJoined = '';
+                for (var i = 0; i < valuesArray.length; ++i) {
+                    valuesJoined += (i === 0 ? '' : ',') + formatter(encoder(valuesArray[i], defaults.encoder, charset, 'value', format));
+                }
+                return [formatter(keyValue) + '=' + valuesJoined];
+            }
             return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset, 'value', format))];
         }
         return [formatter(prefix) + '=' + formatter(String(obj))];
@@ -124,8 +133,8 @@ var stringify = function stringify(
         objKeys = sort ? keys.sort(sort) : keys;
     }
 
-    for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
+    for (var j = 0; j < objKeys.length; ++j) {
+        var key = objKeys[j];
         var value = typeof key === 'object' && key.value !== undefined ? key.value : obj[key];
 
         if (skipNulls && value === null) {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -134,8 +134,7 @@ test('stringify()', function (t) {
     t.test('stringifies a nested array value', function (st) {
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true, arrayFormat: 'indices' }), 'a[b][0]=c&a[b][1]=d');
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true, arrayFormat: 'brackets' }), 'a[b][]=c&a[b][]=d');
-        st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true, arrayFormat: 'comma' }), 'a[b]=c%2Cd');
-        st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true, arrayFormat: 'comma' }), 'a[b]=c,d', '(pending issue #378)', { skip: true });
+        st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true, arrayFormat: 'comma' }), 'a[b]=c,d');
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true }), 'a[b][0]=c&a[b][1]=d');
         st.end();
     });
@@ -162,17 +161,8 @@ test('stringify()', function (t) {
                 { a: { b: ['c', 'd'] } },
                 { allowDots: true, encodeValuesOnly: true, arrayFormat: 'comma' }
             ),
-            'a.b=c%2Cd',
-            'comma: stringifies with dots + comma'
-        );
-        st.equal(
-            qs.stringify(
-                { a: { b: ['c', 'd'] } },
-                { allowDots: true, encodeValuesOnly: true, arrayFormat: 'comma' }
-            ),
             'a.b=c,d',
-            'comma: stringifies with dots + comma (pending issue #378)',
-            { skip: true }
+            'comma: stringifies with dots + comma'
         );
         st.equal(
             qs.stringify(
@@ -237,8 +227,8 @@ test('stringify()', function (t) {
         st.equal(
             qs.stringify({ a: [{ b: 1 }, 2, 3] }, { encodeValuesOnly: true, arrayFormat: 'comma' }),
             '???',
-            'brackets => brackets (pending issue #378)',
-            { skip: true }
+            'brackets => brackets',
+            { skip: 'TODO: figure out what this should do' }
         );
         st.equal(
             qs.stringify({ a: [{ b: 1 }, 2, 3] }, { encodeValuesOnly: true }),
@@ -845,7 +835,12 @@ test('stringify()', function (t) {
         st.equal(qs.stringify(withArray, { encode: false }), 'a[b][0][c]=d&a[b][0][e]=f', 'array, no arrayFormat');
         st.equal(qs.stringify(withArray, { encode: false, arrayFormat: 'bracket' }), 'a[b][0][c]=d&a[b][0][e]=f', 'array, bracket');
         st.equal(qs.stringify(withArray, { encode: false, arrayFormat: 'indices' }), 'a[b][0][c]=d&a[b][0][e]=f', 'array, indices');
-        st.equal(qs.stringify(withArray, { encode: false, arrayFormat: 'comma' }), '???', 'array, comma (pending issue #378)', { skip: true });
+        st.equal(
+            qs.stringify(withArray, { encode: false, arrayFormat: 'comma' }),
+            '???',
+            'array, comma',
+            { skip: 'TODO: figure out what this should do' }
+        );
 
         st.end();
     });


### PR DESCRIPTION
Following changes were made:
* According to the documentation when `encodeValuesOnly = true`, then all characters except the values must not be encoded. This includes brackets and joining characters such as comma. It works perfectly for all other characters except when comma is used to join elements of an array. Then even the comma is encoded. 
* One of the tests had a bug where we assumed the result of `qs.stringify({ a: ['b', 'c', 'd'] }, { arrayFormat: 'comma' })` to be equal to `'a=b,c,d'`. Which is not the expected behavior as for the comma to not be encoded we must either set `encode: false` or `encodeValuesOnly: true`. So the right result would be `'a=b%2Cc%2Cd'` as the default functionality of the function is to encode the complete string.