### PR TITLE
[utils] Simplify check isRegExp

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -212,7 +212,7 @@ var compact = function compact(value) {
 };
 
 var isRegExp = function isRegExp(obj) {
-    return Object.prototype.toString.call(obj) === '[object RegExp]';
+    return obj instanceof RegExp;
 };
 
 var isBuffer = function isBuffer(obj) {


### PR DESCRIPTION
I refactored `isRegExp` to use short method for checking.