### PR TITLE
fix: allow parsing of empty keys in objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,23 @@ assert.deepEqual(primitiveValues, { a: '15', b: 'true', c: 'null' });
 
 If you wish to auto-convert values which look like numbers, booleans, and other values into their primitive counterparts, you can use the [query-types Express JS middleware](https://github.com/xpepermint/query-types) which will auto-convert all request query parameters.
 
+
+### Parsing empty keys
+
+By default, empty keys are omitted after parsing:
+
+```javascript
+var obj = qs.parse("=1&=2");
+assert.deepEqual(obj, {});
+```
+
+It is possible to include empty keys by using `allowEmptyKeys` flag:
+
+```javascript
+var obj = qs.parse("=1&=2", { allowEmptyKeys: true });
+assert.deepEqual(obj, { "": ["1","2"] });
+```
+
 ### Stringifying
 
 [](#preventEval)

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,6 +7,7 @@ var isArray = Array.isArray;
 
 var defaults = {
     allowDots: false,
+    allowEmptyKeys: false,
     allowPrototypes: false,
     allowSparse: false,
     arrayLimit: 20,
@@ -84,6 +85,9 @@ var parseValues = function parseQueryStringValues(str, options) {
         var key, val;
         if (pos === -1) {
             key = options.decoder(part, defaults.decoder, charset, 'key');
+            if (key === '') {
+                continue;
+            }
             val = options.strictNullHandling ? null : '';
         } else {
             key = options.decoder(part.slice(0, pos), defaults.decoder, charset, 'key');
@@ -149,7 +153,7 @@ var parseObject = function (chain, val, options, valuesParsed) {
 };
 
 var parseKeys = function parseQueryStringKeys(givenKey, val, options, valuesParsed) {
-    if (!givenKey) {
+    if (!givenKey && (!options.allowEmptyKeys || givenKey !== '')) {
         return;
     }
 
@@ -169,7 +173,7 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options, valuesPars
     // Stash the parent if it exists
 
     var keys = [];
-    if (parent) {
+    if (parent || (options.allowEmptyKeys && parent === '')) {
         // If we aren't using plain objects, optionally prefix keys that would overwrite object prototype properties
         if (!options.plainObjects && has.call(Object.prototype, parent)) {
             if (!options.allowPrototypes) {
@@ -218,6 +222,7 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
 
     return {
         allowDots: typeof opts.allowDots === 'undefined' ? defaults.allowDots : !!opts.allowDots,
+        allowEmptyKeys: typeof opts.allowEmptyKeys === 'undefined' ? defaults.allowEmptyKeys : !!opts.allowEmptyKeys,
         allowPrototypes: typeof opts.allowPrototypes === 'boolean' ? opts.allowPrototypes : defaults.allowPrototypes,
         allowSparse: typeof opts.allowSparse === 'boolean' ? opts.allowSparse : defaults.allowSparse,
         arrayLimit: typeof opts.arrayLimit === 'number' ? opts.arrayLimit : defaults.arrayLimit,

--- a/test/empty-keys-cases.js
+++ b/test/empty-keys-cases.js
@@ -2,36 +2,36 @@
 
 module.exports = {
     emptyTestCases: [
-        { input: '&', withEmptyKeys: {}, stringifyOutput: '', noEmptyKeys: {} },
-        { input: '&&', withEmptyKeys: {}, stringifyOutput: '', noEmptyKeys: {} },
-        { input: '&=', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {} },
-        { input: '&=&', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {} },
-        { input: '&=&=', withEmptyKeys: { '': ['', ''] }, stringifyOutput: '[0]=&[1]=', noEmptyKeys: {} },
-        { input: '&=&=&', withEmptyKeys: { '': ['', ''] }, stringifyOutput: '[0]=&[1]=', noEmptyKeys: {} },
+        { input: '&', withEmptyKeys: {}, stringifyOutput: '', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '&&', withEmptyKeys: {}, stringifyOutput: '', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '&=', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '&=&', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '&=&=', withEmptyKeys: { '': ['', ''] }, stringifyOutput: '[0]=&[1]=', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '&=&=&', withEmptyKeys: { '': ['', ''] }, stringifyOutput: '[0]=&[1]=', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
 
-        { input: '=', withEmptyKeys: { '': '' }, noEmptyKeys: {}, stringifyOutput: '=' },
-        { input: '=&', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {} },
-        { input: '=&&&', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {} },
-        { input: '=&=&=&', withEmptyKeys: { '': ['', '', ''] }, stringifyOutput: '[0]=&[1]=&[2]=', noEmptyKeys: {} },
-        { input: '=&a[]=b&a[1]=c', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] } },
-        { input: '=a', withEmptyKeys: { '': 'a' }, noEmptyKeys: {}, stringifyOutput: '=a' },
-        { input: '=a', withEmptyKeys: { '': 'a' }, noEmptyKeys: {}, stringifyOutput: '=a' },
-        { input: 'a==a', withEmptyKeys: { a: '=a' }, noEmptyKeys: { a: '=a' }, stringifyOutput: 'a==a' },
+        { input: '=', withEmptyKeys: { '': '' }, noEmptyKeys: {}, stringifyOutput: '=', stringifyOutputNoEmpty: '' },
+        { input: '=&', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '=&&&', withEmptyKeys: { '': '' }, stringifyOutput: '=', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '=&=&=&', withEmptyKeys: { '': ['', '', ''] }, stringifyOutput: '[0]=&[1]=&[2]=', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '=&a[]=b&a[1]=c', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] }, stringifyOutputNoEmpty: 'a[0]=b&a[1]=c' },
+        { input: '=a', withEmptyKeys: { '': 'a' }, noEmptyKeys: {}, stringifyOutput: '=a', stringifyOutputNoEmpty: '' },
+        { input: '=a', withEmptyKeys: { '': 'a' }, noEmptyKeys: {}, stringifyOutput: '=a', stringifyOutputNoEmpty: '' },
+        { input: 'a==a', withEmptyKeys: { a: '=a' }, noEmptyKeys: { a: '=a' }, stringifyOutput: 'a==a', stringifyOutputNoEmpty: 'a==a' },
 
-        { input: '=&a[]=b', withEmptyKeys: { '': '', a: ['b'] }, stringifyOutput: '=&a[0]=b', noEmptyKeys: { a: ['b'] } },
-        { input: '=&a[]=b&a[]=c&a[2]=d', withEmptyKeys: { '': '', a: ['b', 'c', 'd'] }, stringifyOutput: '=&a[0]=b&a[1]=c&a[2]=d', noEmptyKeys: { a: ['b', 'c', 'd'] } },
-        { input: '=a&=b', withEmptyKeys: { '': ['a', 'b'] }, stringifyOutput: '[0]=a&[1]=b', noEmptyKeys: {} },
-        { input: '=a&foo=b', withEmptyKeys: { '': 'a', foo: 'b' }, noEmptyKeys: { foo: 'b' }, stringifyOutput: '=a&foo=b' },
+        { input: '=&a[]=b', withEmptyKeys: { '': '', a: ['b'] }, stringifyOutput: '=&a[0]=b', noEmptyKeys: { a: ['b'] }, stringifyOutputNoEmpty: 'a[0]=b' },
+        { input: '=&a[]=b&a[]=c&a[2]=d', withEmptyKeys: { '': '', a: ['b', 'c', 'd'] }, stringifyOutput: '=&a[0]=b&a[1]=c&a[2]=d', noEmptyKeys: { a: ['b', 'c', 'd'] }, stringifyOutputNoEmpty: 'a[0]=b&a[1]=c&a[2]=d' },
+        { input: '=a&=b', withEmptyKeys: { '': ['a', 'b'] }, stringifyOutput: '[0]=a&[1]=b', noEmptyKeys: {}, stringifyOutputNoEmpty: '' },
+        { input: '=a&foo=b', withEmptyKeys: { '': 'a', foo: 'b' }, noEmptyKeys: { foo: 'b' }, stringifyOutput: '=a&foo=b', stringifyOutputNoEmpty: 'foo=b' },
 
-        { input: 'a[]=b&a=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] } },
-        { input: 'a[]=b&a=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] } },
-        { input: 'a[0]=b&a=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] } },
-        { input: 'a=b&a[]=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] } },
-        { input: 'a=b&a[0]=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] } },
+        { input: 'a[]=b&a=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] }, stringifyOutputNoEmpty: 'a[0]=b&a[1]=c' },
+        { input: 'a[]=b&a=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] }, stringifyOutputNoEmpty: 'a[0]=b&a[1]=c' },
+        { input: 'a[0]=b&a=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] }, stringifyOutputNoEmpty: 'a[0]=b&a[1]=c' },
+        { input: 'a=b&a[]=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] }, stringifyOutputNoEmpty: 'a[0]=b&a[1]=c' },
+        { input: 'a=b&a[0]=c&=', withEmptyKeys: { '': '', a: ['b', 'c'] }, stringifyOutput: '=&a[0]=b&a[1]=c', noEmptyKeys: { a: ['b', 'c'] }, stringifyOutputNoEmpty: 'a[0]=b&a[1]=c' },
 
-        { input: '[]=a&[]=b& []=1', withEmptyKeys: { '': ['a', 'b'], ' ': ['1'] }, stringifyOutput: '[0]=a&[1]=b& [0]=1', noEmptyKeys: { 0: 'a', 1: 'b', ' ': ['1'] } },
-        { input: '[0]=a&[1]=b&a[0]=1&a[1]=2', withEmptyKeys: { '': ['a', 'b'], a: ['1', '2'] }, noEmptyKeys: { 0: 'a', 1: 'b', a: ['1', '2'] }, stringifyOutput: '[0]=a&[1]=b&a[0]=1&a[1]=2' },
-        { input: '[deep]=a&[deep]=2', withEmptyKeys: { '': { deep: ['a', '2'] } }, stringifyOutput: '[deep][0]=a&[deep][1]=2', noEmptyKeys: { deep: ['a', '2'] } },
-        { input: '%5B0%5D=a&%5B1%5D=b', withEmptyKeys: { '': ['a', 'b'] }, stringifyOutput: '[0]=a&[1]=b', noEmptyKeys: { 0: 'a', 1: 'b' } }
+        { input: '[]=a&[]=b& []=1', withEmptyKeys: { '': ['a', 'b'], ' ': ['1'] }, stringifyOutput: '[0]=a&[1]=b& [0]=1', noEmptyKeys: { 0: 'a', 1: 'b', ' ': ['1'] }, stringifyOutputNoEmpty: '0=a&1=b& [0]=1' },
+        { input: '[0]=a&[1]=b&a[0]=1&a[1]=2', withEmptyKeys: { '': ['a', 'b'], a: ['1', '2'] }, noEmptyKeys: { 0: 'a', 1: 'b', a: ['1', '2'] }, stringifyOutput: '[0]=a&[1]=b&a[0]=1&a[1]=2', stringifyOutputNoEmpty: '0=a&1=b&a[0]=1&a[1]=2' },
+        { input: '[deep]=a&[deep]=2', withEmptyKeys: { '': { deep: ['a', '2'] } }, stringifyOutput: '[deep][0]=a&[deep][1]=2', noEmptyKeys: { deep: ['a', '2'] }, stringifyOutputNoEmpty: 'deep[0]=a&deep[1]=2' },
+        { input: '%5B0%5D=a&%5B1%5D=b', withEmptyKeys: { '': ['a', 'b'] }, stringifyOutput: '[0]=a&[1]=b', noEmptyKeys: { 0: 'a', 1: 'b' }, stringifyOutputNoEmpty: '0=a&1=b' }
     ]
 };

--- a/test/parse.js
+++ b/test/parse.js
@@ -889,10 +889,43 @@ test('parse()', function (t) {
 
 test('parses empty keys', function (t) {
     emptyTestCases.forEach(function (testCase) {
-        t.test('skips empty string key with ' + testCase.input, function (st) {
-            st.deepEqual(qs.parse(testCase.input), testCase.noEmptyKeys);
+        t.test('parses an object with empty string key with ' + testCase.input, function (st) {
+            st.deepEqual(qs.parse(testCase.input, { allowEmptyKeys: true }), testCase.withEmptyKeys);
+            st.deepEqual(qs.parse(testCase.stringifyOutput, { allowEmptyKeys: true }), testCase.withEmptyKeys);
 
             st.end();
         });
+
+        t.test('skips empty string key with ' + testCase.input, function (st) {
+            st.deepEqual(
+                qs.parse(testCase.input),
+                testCase.noEmptyKeys
+            );
+
+            st.deepEqual(
+                qs.parse(testCase.input, { allowEmptyKeys: false }),
+                testCase.noEmptyKeys
+            );
+
+            st.end();
+        });
+    });
+
+    t.test('edge case with object/arrays', function (st) {
+        st.deepEqual(
+            qs.parse('[][0]=2&[][1]=3', { allowEmptyKeys: true }),
+            { '': { '': ['2', '3'] } },
+            'array/object conversion',
+            { skip: 'TODO: figure out what this should do' }
+        );
+
+        st.deepEqual(
+            qs.parse('[][0]=2&[][1]=3&[a]=2', { allowEmptyKeys: true }),
+            { '': { '': ['2', '3'], a: '2' } },
+            'array/object conversion',
+            { skip: 'TODO: figure out what this should do' }
+        );
+
+        st.end();
     });
 });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -958,6 +958,7 @@ test('stringifies empty keys', function (t) {
     emptyTestCases.forEach(function (testCase) {
         t.test('stringifies an object with empty string key with ' + testCase.input, function (st) {
             st.deepEqual(qs.stringify(testCase.withEmptyKeys, { encode: false }), testCase.stringifyOutput);
+            st.deepEqual(qs.stringify(testCase.noEmptyKeys, { encode: false }), testCase.stringifyOutputNoEmpty);
 
             st.end();
         });


### PR DESCRIPTION
Resolves #432 


- [x] to add an option to both parse and stringify
- [ ] to have tests, for both parse and stringify, for at least:
  - [x] repeat keys with all array formats
  - [x] bracketed keys with all array formats
  - [x] a lone = (and =& and &= and &=&)
  - [ ] ❌ deep array/object case  

**If we are happy with this implementation and want to proceed:**

 - [x]  to document in the readme
 - [x]  split tests before merge to parse/stringify files
 - [ ] update https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/qs (also `allowSparse` is missing there and maybe other types)
 
 
 Other:
 - Stringify works without an option, so it is potentially a patch but altering parse behaviour only via option seems a safe bet to not accidentally break ppl code, and can be considered as a default behaviour in the next major version?