### PR TITLE
[Fix] do not override array methods/properties (CVE-2021-44907)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,11 +68,6 @@ var merge = function merge(target, source, options) {
         return [target].concat(source);
     }
 
-    var mergeTarget = target;
-    if (isArray(target) && !isArray(source)) {
-        mergeTarget = arrayToObject(target, options);
-    }
-
     if (isArray(target) && isArray(source)) {
         source.forEach(function (item, i) {
             if (has.call(target, i)) {
@@ -89,8 +84,28 @@ var merge = function merge(target, source, options) {
         return target;
     }
 
-    return Object.keys(source).reduce(function (acc, key) {
-        var value = source[key];
+    var mergeTarget = target;
+    var mergeSource = source;
+
+    if (isArray(target) && !isArray(source)) {
+        var restrictedKeys = new Set(Object.getOwnPropertyNames(Array.prototype));
+        var validSourceKeys = Object.keys(source).filter(function (key) {
+            return !restrictedKeys.has(key);
+        });
+
+        if (!validSourceKeys.length) {
+            return target;
+        }
+
+        mergeTarget = arrayToObject(target, options);
+        mergeSource = validSourceKeys.reduce(function (acc, key) {
+            acc[key] = source[key];
+            return acc;
+        }, { });
+    }
+
+    return Object.keys(mergeSource).reduce(function (acc, key) {
+        var value = mergeSource[key];
 
         if (has.call(acc, key)) {
             acc[key] = merge(acc[key], value, options);

--- a/test/parse.js
+++ b/test/parse.js
@@ -201,6 +201,21 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('should not allow overriding any array length', function (st) {
+        st.deepEqual(qs.parse('a=b&a=c&a.length=2', { allowDots: true }), { a: ['b', 'c'] });
+        st.deepEqual(qs.parse('a=b&a=c&a.length=2&a.foo=bar&a.bad=baz', { allowDots: true }), { a: { 0: 'b', 1: 'c', foo: 'bar', bad: 'baz' } });
+        st.end();
+    });
+
+    t.test('should not allow overriding any native array method', function (st) {
+        Object.getOwnPropertyNames(Array.prototype).forEach(function (key) {
+            var str = 'a=b&a=c&a.' + key + '=true';
+            st.deepEqual(qs.parse(str, { allowDots: true }), { a: ['b', 'c'] });
+        });
+
+        st.end();
+    });
+
     t.test('correctly prunes undefined values when converting an array to an object', function (st) {
         st.deepEqual(qs.parse('a[2]=b&a[99999999]=c'), { a: { 2: 'b', 99999999: 'c' } });
         st.end();


### PR DESCRIPTION
This is a fix for [CVE-2021-44907](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44907#:~:text=A%20Denial%20of%20Service%20vulnerability,parse%20function.).
Any property from source object that already exists in `Array.prototype` is ignored.