### PR TITLE
[Fix] `stringify`: with `arrayFormat: comma`, include an explicit `[]` on a single-item array

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -126,7 +126,7 @@ var stringify = function stringify(
                 for (var i = 0; i < valuesArray.length; ++i) {
                     valuesJoined += (i === 0 ? '' : ',') + formatter(encoder(valuesArray[i], defaults.encoder, charset, 'value', format));
                 }
-                return [formatter(keyValue) + '=' + valuesJoined];
+                return [formatter(keyValue) + (i === 1 ? '[]' : '') + '=' + valuesJoined];
             }
             return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset, 'value', format))];
         }

--- a/test/parse.js
+++ b/test/parse.js
@@ -410,6 +410,16 @@ test('parse()', function (t) {
         st.deepEqual(qs.parse('foo=', { comma: true }), { foo: '' });
         st.deepEqual(qs.parse('foo', { comma: true }), { foo: '' });
         st.deepEqual(qs.parse('foo', { comma: true, strictNullHandling: true }), { foo: null });
+
+        // test cases inversed from from stringify tests
+        st.deepEqual(qs.parse('a[0]=c'), { a: ['c'] });
+        st.deepEqual(qs.parse('a[]=c'), { a: ['c'] });
+        st.deepEqual(qs.parse('a[]=c', { comma: true }), { a: ['c'] });
+
+        st.deepEqual(qs.parse('a[0]=c&a[1]=d'), { a: ['c', 'd'] });
+        st.deepEqual(qs.parse('a[]=c&a[]=d'), { a: ['c', 'd'] });
+        st.deepEqual(qs.parse('a=c,d', { comma: true }), { a: ['c', 'd'] });
+
         st.end();
     });
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -131,6 +131,20 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('stringifies an array value with one item vs multiple items', function (st) {
+        st.equal(qs.stringify({ a: ['c'] }, { encodeValuesOnly: true, arrayFormat: 'indices' }), 'a[0]=c');
+        st.equal(qs.stringify({ a: ['c'] }, { encodeValuesOnly: true, arrayFormat: 'brackets' }), 'a[]=c');
+        st.equal(qs.stringify({ a: ['c'] }, { encodeValuesOnly: true, arrayFormat: 'comma' }), 'a[]=c'); // so it parses back as an array
+        st.equal(qs.stringify({ a: ['c'] }, { encodeValuesOnly: true }), 'a[0]=c');
+
+        st.equal(qs.stringify({ a: ['c', 'd'] }, { encodeValuesOnly: true, arrayFormat: 'indices' }), 'a[0]=c&a[1]=d');
+        st.equal(qs.stringify({ a: ['c', 'd'] }, { encodeValuesOnly: true, arrayFormat: 'brackets' }), 'a[]=c&a[]=d');
+        st.equal(qs.stringify({ a: ['c', 'd'] }, { encodeValuesOnly: true, arrayFormat: 'comma' }), 'a=c,d');
+        st.equal(qs.stringify({ a: ['c', 'd'] }, { encodeValuesOnly: true }), 'a[0]=c&a[1]=d');
+
+        st.end();
+    });
+
     t.test('stringifies a nested array value', function (st) {
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true, arrayFormat: 'indices' }), 'a[b][0]=c&a[b][1]=d');
         st.equal(qs.stringify({ a: { b: ['c', 'd'] } }, { encodeValuesOnly: true, arrayFormat: 'brackets' }), 'a[b][]=c&a[b][]=d');


### PR DESCRIPTION
Fixes #434