### PR TITLE
Nested Brackets

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -687,6 +687,11 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('params containing brackets within brackets', function (st) {
+        st.deepEqual(qs.parse({ 'a[b[]]': 'c' }), { a: { "b[]": 'c' } });
+        st.end();
+    });
+
     t.test('add keys to objects', function (st) {
         st.deepEqual(
             qs.parse('a[b]=c&a=d'),


### PR DESCRIPTION
- Add unit test for nested brackets (`?foo[bar[]]=baz`)

```
# params containing brackets within brackets
not ok 211 should be deeply equivalent
  ---
    operator: deepEqual
    expected: |-
      { a: { 'b[]': 'c' } }
    actual: |-
      { 'a[b': [ 'c' ] }
    at: Test.<anonymous> (/home/runner/work/qs/qs/test/parse.js:6:1420)
    stack: |-
      Error: should be deeply equivalent
          at Test.assert (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:493:48)
          at Test.tapeDeepEqual (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:748:7)
          at Test.<anonymous> (/home/runner/work/qs/qs/test/parse.js:6:1420)
          at Test.run (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:127:28)
          at Test._end (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:399:5)
          at Test.<anonymous> (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:398:34)
          at Test.emit (events.js:92:17)
          at completeEnd (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:404:27)
          at next (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:418:4)
          at Test._end (/home/runner/work/qs/qs/node_modules/tape/lib/test.js:438:2)
```
