### PR TITLE
Disable decodeDotInKeys by default to restore previous behavior

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -14,7 +14,7 @@ var defaults = {
     charset: 'utf-8',
     charsetSentinel: false,
     comma: false,
-    decodeDotInKeys: true,
+    decodeDotInKeys: false,
     decoder: utils.decode,
     delimiter: '&',
     depth: 5,

--- a/test/parse.js
+++ b/test/parse.js
@@ -108,6 +108,11 @@ test('parse()', function (t) {
             { 'name.obj.subobject': { 'first.godly.name': 'John', last: 'Doe' } },
             'with allowDots true and decodeDotInKeys true'
         );
+        st.deepEqual(
+            qs.parse('name%252Eobj.first=John&name%252Eobj.last=Doe'),
+            { 'name%2Eobj.first': 'John', 'name%2Eobj.last': 'Doe' },
+            'with allowDots and decodeDotInKeys undefined'
+        );
 
         st.end();
     });


### PR DESCRIPTION
Fixes #500.

Restores the default behavior as it was before `v6.12.0`.

All test cases with encoded dots explicitly set the relevant options, so the default behavior was not tested.
Added an extra test case for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Changed the default behavior for parsing keys with dots in query strings to improve clarity and predictability.
- **Tests**
	- Added a new test case to ensure reliable parsing of keys with dots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->