### PR TITLE
[meta] ship only the dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "funding": {
         "url": "https://github.com/sponsors/ljharb"
     },
-    "main": "lib/index.js",
+    "main": "dist/qs.js",
+    "files": [
+        "dist"
+    ],
     "sideEffects": false,
     "contributors": [
         {


### PR DESCRIPTION
This will reduce your on-disk footprint from 300k to ~56k, and your package tar from 78k to 23k :) 

I see you [do care about your footprint](https://github.com/ljharb/qs/commit/f09cffccd83957218d7b6d03774e866b49595afb), but you ship your entire repo, and your entry point was the `lib/index`... 

Here's your current state:

```
$ tree node_modules/qs/
node_modules/qs/
├── CHANGELOG.md
├── LICENSE.md
├── README.md
├── dist
│   └── qs.js
├── lib
│   ├── formats.js
│   ├── index.js
│   ├── parse.js
│   ├── stringify.js
│   └── utils.js
├── package.json
└── test
    ├── empty-keys-cases.js
    ├── parse.js
    ├── stringify.js
    └── utils.js
$ du -h node_modules/qs
116.0K  node_modules/qs/test
52.0K   node_modules/qs/dist
8.0K    node_modules/qs/.github
44.0K   node_modules/qs/lib
300.0K  node_modules/qs
$
```

And the diff in result of `npm pack`:

```
$ ls -la qs-*                                                                                                                                                  <aws:lwf>
-rw-r--r-- 1 osher osher 78637 May  5 19:20 qs-6.12.1.before-change.tgz
-rw-r--r-- 1 osher osher 23127 May  5 19:20 qs-6.12.1.tgz
```
