### PR TITLE
fix: parse url-encoded square brackets

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -55,6 +55,7 @@ var parseValues = function parseQueryStringValues(str, options) {
     var obj = { __proto__: null };
 
     var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
+    cleanStr = cleanStr.replace(/%5B/gi, '[').replace(/%5D/gi, ']');
     var limit = options.parameterLimit === Infinity ? undefined : options.parameterLimit;
     var parts = cleanStr.split(options.delimiter, limit);
     var skipIndex = -1; // Keep track of where the utf8 sentinel was found

--- a/test/parse.js
+++ b/test/parse.js
@@ -571,6 +571,15 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('parses url-encoded brackets holds array of arrays when having two parts of strings with comma as array divider', function (st) {
+        st.deepEqual(qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=4,5,6', { comma: true }), { foo: [['1', '2', '3'], ['4', '5', '6']] });
+        st.deepEqual(qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=', { comma: true }), { foo: [['1', '2', '3'], ''] });
+        st.deepEqual(qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=,', { comma: true }), { foo: [['1', '2', '3'], ['', '']] });
+        st.deepEqual(qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=a', { comma: true }), { foo: [['1', '2', '3'], 'a'] });
+
+        st.end();
+    });
+
     t.test('parses comma delimited array while having percent-encoded comma treated as normal text', function (st) {
         st.deepEqual(qs.parse('foo=a%2Cb', { comma: true }), { foo: 'a,b' });
         st.deepEqual(qs.parse('foo=a%2C%20b,d', { comma: true }), { foo: ['a, b', 'd'] });


### PR DESCRIPTION
I noticed that url-encoded square brackets, i.e. `%5B` and `%5D`, do not get correctly parsed in this case

```javascript
t.test(
    'parses encoded brackets holds array of arrays when having two parts of strings with comma as array divider',
    function (st) {
        st.deepEqual(
            // foo[]=1,2,3&foo[]=4,5,6
            qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=4,5,6', { comma: true }), 
            { foo: [['1', '2', '3'], ['4', '5', '6']] }
        );
        st.deepEqual(
            // foo[]=1,2,3&foo[]=
            qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=', { comma: true }), 
            { foo: [['1', '2', '3'], ''] }
        );
        st.deepEqual(
            // foo[]=1,2,3&foo[]=
            qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=,', { comma: true }), 
            { foo: [['1', '2', '3'], ['', '']] }
        );
        st.deepEqual(
            // foo[]=1,2,3&foo[]=a
            qs.parse('foo%5B%5D=1,2,3&foo%5B%5D=a', { comma: true }),
            { foo: [['1', '2', '3'], 'a'] }
        );
        st.end();
    }
);
```

This PR fixes this by replacing `%5B` or `%5b` with `[` and `%5D` or `%5d` with `]` before splitting the string into delimited parts inside `parseQueryStringValues`.

I've added the test mentioned above into into the parse test suite.