### PR TITLE
Fix parsing of keys containing literal `[]` inside bracket groups

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -214,9 +214,12 @@ var parseObject = function (chain, val, options, valuesParsed) {
     return leaf;
 };
 
-var splitKeyIntoSegments = function splitKeyIntoSegments(givenKey, options) {
-    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+// Split a key like "a[b][c[]]" into ['a', '[b]', '[c[]]'] while preserving
+// qs parse semantics for depth/prototype guards.
+var splitKeyIntoSegments = function splitKeyIntoSegments(originalKey, options) {
+    var key = options.allowDots ? originalKey.replace(/\.([^.[]+)/g, '[$1]') : originalKey;
 
+    // depth <= 0 keeps the whole key as one segment
     if (options.depth <= 0) {
         if (!options.plainObjects && has.call(Object.prototype, key)) {
             if (!options.allowPrototypes) {
@@ -227,14 +230,11 @@ var splitKeyIntoSegments = function splitKeyIntoSegments(givenKey, options) {
         return [key];
     }
 
-    var brackets = /(\[[^[\]]*])/;
-    var child = /(\[[^[\]]*])/g;
+    var segments = [];
 
-    var segment = brackets.exec(key);
-    var parent = segment ? key.slice(0, segment.index) : key;
-
-    var keys = [];
-
+    // parent before the first '[' (may be empty if key starts with '[')
+    var first = key.indexOf('[');
+    var parent = first >= 0 ? key.slice(0, first) : key;
     if (parent) {
         if (!options.plainObjects && has.call(Object.prototype, parent)) {
             if (!options.allowPrototypes) {
@@ -242,32 +242,62 @@ var splitKeyIntoSegments = function splitKeyIntoSegments(givenKey, options) {
             }
         }
 
-        keys[keys.length] = parent;
+        segments[segments.length] = parent;
     }
 
-    var i = 0;
-    while ((segment = child.exec(key)) !== null && i < options.depth) {
-        i += 1;
+    var n = key.length;
+    var open = first;
+    var collected = 0;
 
-        var segmentContent = segment[1].slice(1, -1);
-        if (!options.plainObjects && has.call(Object.prototype, segmentContent)) {
-            if (!options.allowPrototypes) {
-                return;
+    while (open >= 0 && collected < options.depth) {
+        var level = 1;
+        var i = open + 1;
+        var close = -1;
+
+        // balance nested '[' and ']' inside this bracket group using a nesting level counter
+        while (i < n && close < 0) {
+            var cu = key.charCodeAt(i);
+            if (cu === 0x5B) { // '['
+                level += 1;
+            } else if (cu === 0x5D) { // ']'
+                level -= 1;
+                if (level === 0) {
+                    close = i; // found matching close; loop will exit by condition
+                }
             }
+            i += 1;
         }
 
-        keys[keys.length] = segment[1];
+        if (close < 0) {
+            // Unterminated group: wrap the raw remainder in one bracket pair so it stays
+            // a single literal segment (e.g. "[[]b" -> "[[]b]"); we do not infer missing ']'.
+            segments[segments.length] = '[' + key.slice(open) + ']';
+            return segments;
+        }
+
+        var seg = key.slice(open, close + 1);
+        // prototype guard for the content of this group
+        var content = seg.slice(1, -1);
+        if (!options.plainObjects && has.call(Object.prototype, content) && !options.allowPrototypes) {
+            return;
+        }
+
+        segments[segments.length] = seg;
+        collected += 1;
+
+        // find the next '[' after this balanced group
+        open = key.indexOf('[', close + 1);
     }
 
-    if (segment) {
+    if (open >= 0) {
         if (options.strictDepth === true) {
             throw new RangeError('Input depth exceeded depth option of ' + options.depth + ' and strictDepth is true');
         }
 
-        keys[keys.length] = '[' + key.slice(segment.index) + ']';
+        segments[segments.length] = '[' + key.slice(open) + ']';
     }
 
-    return keys;
+    return segments;
 };
 
 var parseKeys = function parseQueryStringKeys(givenKey, val, options, valuesParsed) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -210,6 +210,9 @@ test('parse()', function (t) {
     t.test('uses original key when depth = 0', function (st) {
         st.deepEqual(qs.parse('a[0]=b&a[1]=c', { depth: 0 }), { 'a[0]': 'b', 'a[1]': 'c' });
         st.deepEqual(qs.parse('a[0][0]=b&a[0][1]=c&a[1]=d&e=2', { depth: 0 }), { 'a[0][0]': 'b', 'a[0][1]': 'c', 'a[1]': 'd', e: '2' });
+        st.deepEqual(qs.parse('a.b=c', { depth: 0, allowDots: true }), { 'a[b]': 'c' }, 'normalizes dots before applying depth-0 behavior');
+        st.deepEqual(qs.parse('toString=foo', { depth: 0 }), {}, 'respects prototype guard at depth 0');
+        st.deepEqual(qs.parse('toString=foo', { depth: 0, allowPrototypes: true }), { toString: 'foo' }, 'allows prototypes at depth 0 when enabled');
         st.end();
     });
 
@@ -260,6 +263,52 @@ test('parse()', function (t) {
     t.test('parses a nested array', function (st) {
         st.deepEqual(qs.parse('a[b][]=c&a[b][]=d'), { a: { b: ['c', 'd'] } });
         st.deepEqual(qs.parse('a[>=]=25'), { a: { '>=': '25' } });
+        st.end();
+    });
+
+    t.test('parses keys with literal [] inside a bracket group (#493)', function (st) {
+        // A bracket pair inside a bracket group should be treated literally as part of the key
+        st.deepEqual(
+            qs.parse('search[withbracket[]]=foobar'),
+            { search: { 'withbracket[]': 'foobar' } },
+            'treats inner [] literally when inside a bracket group'
+        );
+
+        // Single-level variant
+        st.deepEqual(
+            qs.parse('a[b[]]=c'),
+            { a: { 'b[]': 'c' } },
+            'keeps "b[]" as a literal key'
+        );
+
+        // Nested with an array push on the outer level
+        st.deepEqual(
+            qs.parse('list[][x[]]=y'),
+            { list: [{ 'x[]': 'y' }] },
+            'preserves inner [] while still treating outer [] as array push'
+        );
+
+        // Multiple nested bracket pairs: inner [] remains literal as part of the key
+        st.deepEqual(
+            qs.parse('a[b[c[]]]=d'),
+            { a: { 'b[c[]]': 'd' } },
+            'treats "b[c[]]" as a literal key inside the bracket group'
+        );
+
+        // Depth limits with literal brackets: preserve inner [] while limiting bracket-group parsing
+        st.deepEqual(
+            qs.parse('a[b[c[]]][d]=e', { depth: 1 }),
+            { a: { 'b[c[]]': { '[d]': 'e' } } },
+            'respects depth: 1 and preserves literal inner [] in the parsed key'
+        );
+
+        // Unterminated inner bracket group is wrapped as a literal remainder segment
+        st.deepEqual(
+            qs.parse('a[[]b=c'),
+            { a: { '[[]b': 'c' } },
+            'handles unterminated inner bracket groups without throwing'
+        );
+
         st.end();
     });
 


### PR DESCRIPTION
### Problem

`qs` splits bracket groups with a regex that *forbids* `[]` inside a group:

```js
var child = /(\[[^[][^\]]*])/g; // original: /(\[[^[\]]*])/g
```

This causes keys like `search[withbracket[]]` to split into `"[withbracket]"`, then `"[]"`, leaving the inner `[]` detached from the literal segment. Downstream, it can no longer be treated as a single literal key.

### Repro

```js
// expected:
qs.parse('search[withbracket[]]=foobar');
// => { search: { 'withbracket[]': 'foobar' } }

// actual (today):
// inner [] is split out, so the key can’t be treated as one literal segment
```

### Fix approach

Backport [`splitKeyIntoSegments`](https://github.com/techouse/qs/blob/1952f973a002eae77b08536c6e226603141f5e89/lib/src/extensions/decode.dart#L371) from [qs_dart](https://github.com/techouse/qs) and replace the regex child matcher with a **balanced bracket splitter** that treats `[]` *inside* a bracket group as literal content (only outer `[]` act as array push). This preserves `withbracket[]` as a single segment.

### Notes

- Does not change existing semantics for `[]` at the *outermost* level (array push).
- Honors existing options: `allowDots`, `depth`, `strictDepth`, `allowPrototypes`, etc.

### Test snippet

```js
t.test('parses keys with literal [] inside a bracket group (#493)', function (st) {
    // A bracket pair inside a bracket group should be treated literally as part of the key
    st.deepEqual(
        qs.parse('search[withbracket[]]=foobar'),
        { search: { 'withbracket[]': 'foobar' } },
        'treats inner [] literally when inside a bracket group'
    );

    // Single-level variant
    st.deepEqual(
        qs.parse('a[b[]]=c'),
        { a: { 'b[]': 'c' } },
        'keeps "b[]" as a literal key'
    );

    // Nested with an array push on the outer level
    st.deepEqual(
        qs.parse('list[][x[]]=y'),
        { list: [{ 'x[]': 'y' }] },
        'preserves inner [] while still treating outer [] as array push'
    );

    // Multiple nested bracket pairs: inner [] remains literal as part of the key
    st.deepEqual(
        qs.parse('a[b[c[]]]=d'),
        { a: { 'b[c[]]': 'd' } },
        'treats "b[c[]]" as a literal key inside the bracket group'
    );

    // Depth limits with literal brackets: preserve inner [] while limiting bracket-group parsing
    st.deepEqual(
        qs.parse('a[b[c[]]][d]=e', { depth: 1 }),
        { a: { 'b[c[]]': { '[d]': 'e' } } },
        'respects depth: 1 and preserves literal inner [] in the parsed key'
    );

    // Unterminated inner bracket group is wrapped as a literal remainder segment
    st.deepEqual(
        qs.parse('a[[]b=c'),
        { a: { '[[]b': 'c' } },
        'handles unterminated inner bracket groups without throwing'
    );

    st.end();
});
```

---

Fixes https://github.com/ljharb/qs/issues/493