### PR TITLE
Correct changelog entry for arrayLimit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## **6.14.1**
-- [Fix] ensure arrayLength applies to `[]` notation as well
+- [Fix] (breaking change) ensure arrayLimit applies to `[]` notation as well
 - [Fix] `parse`: when a custom decoder returns `null` for a key, ignore that key
 - [Refactor] `parse`: extract key segment splitting helper
 - [meta] add threat model


### PR DESCRIPTION
- should mention `arrayLimit` because it's what devs use and `arrayLength` is internal variable
- should warn that it is a breaking change (example of people reporting behavior change: https://github.com/ljharb/qs/issues/537)