### PR TITLE
add allowDotsForNumbers option to convert from brackets of indices to dots

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,7 @@ export default [
                 'error',
                 { max: 150 },
             ],
-            'max-params': ['error', 18],
+            'max-params': ['error', 19],
             'max-statements': ['error', 100],
             'multiline-comment-style': 'off',
             'no-continue': 'warn',

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,6 +7,7 @@ var isArray = Array.isArray;
 
 var defaults = {
     allowDots: false,
+    allowDotsForIndices: false,
     allowEmptyArrays: false,
     allowPrototypes: false,
     allowSparse: false,
@@ -215,7 +216,8 @@ var parseObject = function (chain, val, options, valuesParsed) {
 };
 
 var splitKeyIntoSegments = function splitKeyIntoSegments(givenKey, options) {
-    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+    var key = options.allowDots
+        ? options.allowDotsForIndices ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey.replace(/\.(?!\d)([^.[\]]+)/g, '[$1]') : givenKey;
 
     if (options.depth <= 0) {
         if (!options.plainObjects && has.call(Object.prototype, key)) {
@@ -317,10 +319,17 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         throw new TypeError('The duplicates option must be either combine, first, or last');
     }
 
-    var allowDots = typeof opts.allowDots === 'undefined' ? opts.decodeDotInKeys === true ? true : defaults.allowDots : !!opts.allowDots;
+    if ('allowDots' in opts && opts.allowDots === false && opts.allowDotsForIndices) {
+        throw new TypeError('allowDots cannot be false and allowDotsForIndices true at the same time');
+    }
+
+    var allowDots = typeof opts.allowDots === 'undefined' ? opts.decodeDotInKeys === true || !!opts.allowDotsForIndices
+        ? true : defaults.allowDots : !!opts.allowDots;
+    var allowDotsForIndices = typeof opts.allowDotsForIndices === 'undefined' ? allowDots : !!opts.allowDotsForIndices;
 
     return {
         allowDots: allowDots,
+        allowDotsForIndices: allowDotsForIndices,
         allowEmptyArrays: typeof opts.allowEmptyArrays === 'boolean' ? !!opts.allowEmptyArrays : defaults.allowEmptyArrays,
         allowPrototypes: typeof opts.allowPrototypes === 'boolean' ? opts.allowPrototypes : defaults.allowPrototypes,
         allowSparse: typeof opts.allowSparse === 'boolean' ? opts.allowSparse : defaults.allowSparse,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,7 +7,7 @@ var isArray = Array.isArray;
 
 var defaults = {
     allowDots: false,
-    allowDotsForIndices: false,
+    allowDotsForNumbers: false,
     allowEmptyArrays: false,
     allowPrototypes: false,
     allowSparse: false,
@@ -216,8 +216,8 @@ var parseObject = function (chain, val, options, valuesParsed) {
 };
 
 var splitKeyIntoSegments = function splitKeyIntoSegments(givenKey, options) {
-    var key = options.allowDots
-        ? options.allowDotsForIndices ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey.replace(/\.(?!\d)([^.[\]]+)/g, '[$1]') : givenKey;
+    var key = options.allowDots ? options.allowDotsForNumbers
+        ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey.replace(/\.(?!\d+(?:\.|\[|\]|$))([^.[]+)/g, '[$1]') : givenKey;
 
     if (options.depth <= 0) {
         if (!options.plainObjects && has.call(Object.prototype, key)) {
@@ -319,17 +319,17 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         throw new TypeError('The duplicates option must be either combine, first, or last');
     }
 
-    if ('allowDots' in opts && opts.allowDots === false && opts.allowDotsForIndices) {
-        throw new TypeError('allowDots cannot be false and allowDotsForIndices true at the same time');
+    if ('allowDots' in opts && opts.allowDots === false && opts.allowDotsForNumbers) {
+        throw new TypeError('allowDots cannot be false and allowDotsForNumbers true at the same time');
     }
 
-    var allowDots = typeof opts.allowDots === 'undefined' ? opts.decodeDotInKeys === true || !!opts.allowDotsForIndices
+    var allowDots = typeof opts.allowDots === 'undefined' ? opts.decodeDotInKeys === true || !!opts.allowDotsForNumbers
         ? true : defaults.allowDots : !!opts.allowDots;
-    var allowDotsForIndices = typeof opts.allowDotsForIndices === 'undefined' ? allowDots : !!opts.allowDotsForIndices;
+    var allowDotsForNumbers = typeof opts.allowDotsForNumbers === 'undefined' ? allowDots : !!opts.allowDotsForNumbers;
 
     return {
         allowDots: allowDots,
-        allowDotsForIndices: allowDotsForIndices,
+        allowDotsForNumbers: allowDotsForNumbers,
         allowEmptyArrays: typeof opts.allowEmptyArrays === 'boolean' ? !!opts.allowEmptyArrays : defaults.allowEmptyArrays,
         allowPrototypes: typeof opts.allowPrototypes === 'boolean' ? opts.allowPrototypes : defaults.allowPrototypes,
         allowSparse: typeof opts.allowSparse === 'boolean' ? opts.allowSparse : defaults.allowSparse,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -10,6 +10,9 @@ var arrayPrefixGenerators = {
         return prefix + '[]';
     },
     comma: 'comma',
+    dots: function dots(prefix, key) {
+        return prefix + '.' + key;
+    },
     indices: function indices(prefix, key) {
         return prefix + '[' + key + ']';
     },
@@ -30,6 +33,7 @@ var defaultFormat = formats['default'];
 var defaults = {
     addQueryPrefix: false,
     allowDots: false,
+    allowDotsForIndices: false,
     allowEmptyArrays: false,
     arrayFormat: 'indices',
     charset: 'utf-8',
@@ -75,6 +79,7 @@ var stringify = function stringify(
     filter,
     sort,
     allowDots,
+    allowDotsForIndices,
     serializeDate,
     format,
     formatter,
@@ -191,6 +196,7 @@ var stringify = function stringify(
             filter,
             sort,
             allowDots,
+            allowDotsForIndices,
             serializeDate,
             format,
             formatter,
@@ -220,6 +226,10 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
         throw new TypeError('Encoder has to be a function.');
     }
 
+    if ('allowDots' in opts && opts.allowDots === false && opts.allowDotsForIndices) {
+        throw new TypeError('allowDots cannot be false and allowDotsForIndices true at the same time');
+    }
+
     var charset = opts.charset || defaults.charset;
     if (typeof opts.charset !== 'undefined' && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
         throw new TypeError('The charset option must be either utf-8, iso-8859-1, or undefined');
@@ -244,6 +254,8 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
         arrayFormat = opts.arrayFormat;
     } else if ('indices' in opts) {
         arrayFormat = opts.indices ? 'indices' : 'repeat';
+    } else if (opts.allowDotsForIndices) {
+        arrayFormat = 'dots';
     } else {
         arrayFormat = defaults.arrayFormat;
     }
@@ -253,10 +265,12 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
     }
 
     var allowDots = typeof opts.allowDots === 'undefined' ? opts.encodeDotInKeys === true ? true : defaults.allowDots : !!opts.allowDots;
+    var allowDotsForIndices = opts.allowDotsForIndices;
 
     return {
         addQueryPrefix: typeof opts.addQueryPrefix === 'boolean' ? opts.addQueryPrefix : defaults.addQueryPrefix,
         allowDots: allowDots,
+        allowDotsForIndices: allowDotsForIndices,
         allowEmptyArrays: typeof opts.allowEmptyArrays === 'boolean' ? !!opts.allowEmptyArrays : defaults.allowEmptyArrays,
         arrayFormat: arrayFormat,
         charset: charset,
@@ -330,6 +344,7 @@ module.exports = function (object, opts) {
             options.filter,
             options.sort,
             options.allowDots,
+            options.allowDotsForIndices,
             options.serializeDate,
             options.format,
             options.formatter,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -265,7 +265,7 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
     }
 
     var allowDots = typeof opts.allowDots === 'undefined' ? opts.encodeDotInKeys === true ? true : defaults.allowDots : !!opts.allowDots;
-    var allowDotsForIndices = opts.allowDotsForIndices;
+    var allowDotsForIndices = !!opts.allowDotsForIndices;
 
     return {
         addQueryPrefix: typeof opts.addQueryPrefix === 'boolean' ? opts.addQueryPrefix : defaults.addQueryPrefix,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -33,7 +33,7 @@ var defaultFormat = formats['default'];
 var defaults = {
     addQueryPrefix: false,
     allowDots: false,
-    allowDotsForIndices: false,
+    allowDotsForNumbers: false,
     allowEmptyArrays: false,
     arrayFormat: 'indices',
     charset: 'utf-8',
@@ -79,7 +79,7 @@ var stringify = function stringify(
     filter,
     sort,
     allowDots,
-    allowDotsForIndices,
+    allowDotsForNumbers,
     serializeDate,
     format,
     formatter,
@@ -196,7 +196,7 @@ var stringify = function stringify(
             filter,
             sort,
             allowDots,
-            allowDotsForIndices,
+            allowDotsForNumbers,
             serializeDate,
             format,
             formatter,
@@ -226,8 +226,8 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
         throw new TypeError('Encoder has to be a function.');
     }
 
-    if ('allowDots' in opts && opts.allowDots === false && opts.allowDotsForIndices) {
-        throw new TypeError('allowDots cannot be false and allowDotsForIndices true at the same time');
+    if ('allowDots' in opts && opts.allowDots === false && opts.allowDotsForNumbers) {
+        throw new TypeError('allowDots cannot be false and allowDotsForNumbers true at the same time');
     }
 
     var charset = opts.charset || defaults.charset;
@@ -254,7 +254,7 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
         arrayFormat = opts.arrayFormat;
     } else if ('indices' in opts) {
         arrayFormat = opts.indices ? 'indices' : 'repeat';
-    } else if (opts.allowDotsForIndices) {
+    } else if (opts.allowDotsForNumbers) {
         arrayFormat = 'dots';
     } else {
         arrayFormat = defaults.arrayFormat;
@@ -265,12 +265,12 @@ var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
     }
 
     var allowDots = typeof opts.allowDots === 'undefined' ? opts.encodeDotInKeys === true ? true : defaults.allowDots : !!opts.allowDots;
-    var allowDotsForIndices = !!opts.allowDotsForIndices;
+    var allowDotsForNumbers = !!opts.allowDotsForNumbers;
 
     return {
         addQueryPrefix: typeof opts.addQueryPrefix === 'boolean' ? opts.addQueryPrefix : defaults.addQueryPrefix,
         allowDots: allowDots,
-        allowDotsForIndices: allowDotsForIndices,
+        allowDotsForNumbers: allowDotsForNumbers,
         allowEmptyArrays: typeof opts.allowEmptyArrays === 'boolean' ? !!opts.allowEmptyArrays : defaults.allowEmptyArrays,
         arrayFormat: arrayFormat,
         charset: charset,
@@ -344,7 +344,7 @@ module.exports = function (object, opts) {
             options.filter,
             options.sort,
             options.allowDots,
-            options.allowDotsForIndices,
+            options.allowDotsForNumbers,
             options.serializeDate,
             options.format,
             options.formatter,

--- a/test/parse.js
+++ b/test/parse.js
@@ -63,6 +63,12 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('allows enabling dots for indices', function (st) {
+        st.deepEqual(qs.parse('a.0.b=d&a.1.c=e', { allowDotsForIndices: false, allowDots: true }), { 'a.0': { b: 'd' }, 'a.1': { c: 'e' } }, 'with allowDotsForIndices false and allowDots true');
+        st.deepEqual(qs.parse('a.b.0=c&a.c.0=d', { allowDotsForIndices: true }), { a: { b: ['c'], c: ['d'] } }, 'with only allowDotsForIndices true');
+        st.end();
+    });
+
     t.test('decode dot keys correctly', function (st) {
         st.deepEqual(
             qs.parse('name%252Eobj.first=John&name%252Eobj.last=Doe', { allowDots: false, decodeDotInKeys: false }),

--- a/test/parse.js
+++ b/test/parse.js
@@ -63,9 +63,9 @@ test('parse()', function (t) {
         st.end();
     });
 
-    t.test('allows enabling dots for indices', function (st) {
-        st.deepEqual(qs.parse('a.0.b=d&a.1.c=e', { allowDotsForIndices: false, allowDots: true }), { 'a.0': { b: 'd' }, 'a.1': { c: 'e' } }, 'with allowDotsForIndices false and allowDots true');
-        st.deepEqual(qs.parse('a.b.0=c&a.c.0=d', { allowDotsForIndices: true }), { a: { b: ['c'], c: ['d'] } }, 'with only allowDotsForIndices true');
+    t.test('allows enabling dots for numbers', function (st) {
+        st.deepEqual(qs.parse('a.0.b=d&a.1.c=e', { allowDotsForNumbers: false, allowDots: true }), { 'a.0': { b: 'd' }, 'a.1': { c: 'e' } }, 'with allowDotsForNumbers false and allowDots true');
+        st.deepEqual(qs.parse('a.b.0=c&a.c.0=d', { allowDotsForNumbers: true }), { a: { b: ['c'], c: ['d'] } }, 'with only allowDotsForIndices true');
         st.end();
     });
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -227,6 +227,12 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('`allowDotsForIndices` option: stringifies a nested object with converting indices to dot notation', function (st) {
+        st.equal(qs.stringify({ a: [1, 2] }, { allowDotsForIndices: true }), 'a.0=1&a.1=2');
+        st.equal(qs.stringify({ a: [{ b: 'c', d: 'e' }] }, { allowDotsForIndices: true, allowDots: true }), 'a.0.b=c&a.0.d=e');
+        st.end();
+    });
+
     t.test('stringifies an array value', function (st) {
         st.equal(
             qs.stringify({ a: ['b', 'c', 'd'] }, { arrayFormat: 'indices' }),

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -227,9 +227,9 @@ test('stringify()', function (t) {
         st.end();
     });
 
-    t.test('`allowDotsForIndices` option: stringifies a nested object with converting indices to dot notation', function (st) {
-        st.equal(qs.stringify({ a: [1, 2] }, { allowDotsForIndices: true }), 'a.0=1&a.1=2');
-        st.equal(qs.stringify({ a: [{ b: 'c', d: 'e' }] }, { allowDotsForIndices: true, allowDots: true }), 'a.0.b=c&a.0.d=e');
+    t.test('`allowDotsForNumbers` option: stringifies a nested object with converting numbers to dot notation', function (st) {
+        st.equal(qs.stringify({ a: [1, 2] }, { allowDotsForNumbers: true }), 'a.0=1&a.1=2');
+        st.equal(qs.stringify({ a: [{ b: 'c', d: 'e' }] }, { allowDotsForNumbers: true, allowDots: true }), 'a.0.b=c&a.0.d=e');
         st.end();
     });
 


### PR DESCRIPTION
resolves #516
 
`allowDots` does not convert bracket notation for array indices to dots. 
This PR adds an option `allowDotsForIndices` which does that.