### PR TITLE
Improve array parsing performance

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -287,9 +287,17 @@ var combine = function combine(a, b, arrayLimit, plainObjects) {
         return a;
     }
 
-    var result = [].concat(a, b);
-    if (result.length > arrayLimit) {
-        return markOverflow(arrayToObject(result, { plainObjects: plainObjects }), result.length - 1);
+    var length;
+    var result;
+    if (Array.isArray(a)) {
+        length = Array.isArray(b) ? a.push.apply(a, b) : a.push(b);
+        result = a;
+    } else {
+        result = [].concat(a, b);
+        length = result.length;
+    }
+    if (length > arrayLimit) {
+        return markOverflow(arrayToObject(result, { plainObjects: plainObjects }), length - 1);
     }
     return result;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,7 +116,10 @@ var merge = function merge(target, source, options) {
     }
 
     if (isArray(target) && isArray(source)) {
-        source.forEach(function (item, i) {
+        var sourceOwnProperties = Object.getOwnPropertyNames(source);
+        for (var j = 0; j < sourceOwnProperties.length - 1; j++) {
+            var i = sourceOwnProperties[j];
+            var item = source[i];
             if (has.call(target, i)) {
                 var targetItem = target[i];
                 if (targetItem && typeof targetItem === 'object' && item && typeof item === 'object') {
@@ -127,7 +130,7 @@ var merge = function merge(target, source, options) {
             } else {
                 target[i] = item;
             }
-        });
+        }
         return target;
     }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -143,9 +143,9 @@ test('combine()', function (t) {
         var b = [2];
         var combined = utils.combine(a, b);
 
-        st.deepEqual(a, [1], 'a is not mutated');
+        st.deepEqual(a, [1, 2], 'a is mutated');
         st.deepEqual(b, [2], 'b is not mutated');
-        st.notEqual(a, combined, 'a !== combined');
+        st.deepEqual(a, combined, 'a === combined');
         st.notEqual(b, combined, 'b !== combined');
         st.deepEqual(combined, [1, 2], 'combined is a + b');
 
@@ -167,9 +167,9 @@ test('combine()', function (t) {
         st.deepEqual([1, 2], combinedAnB, 'first argument is array-wrapped when not an array');
 
         var combinedABn = utils.combine(a, bN);
-        st.deepEqual(a, [aN], 'a is not mutated');
+        st.deepEqual(a, [aN, bN], 'a is mutated');
         st.notEqual(aN, combinedABn, 'a + bN !== aN');
-        st.notEqual(a, combinedABn, 'a + bN !== a');
+        st.deepEqual(a, combinedABn, 'a + bN === a');
         st.notEqual(bN, combinedABn, 'a + bN !== bN');
         st.notEqual(b, combinedABn, 'a + bN !== b');
         st.deepEqual([1, 2], combinedABn, 'second argument is array-wrapped when not an array');


### PR DESCRIPTION
This PR improves the performance by a few orders of magnitude in my benchmarks, mostly by changing O(n^2) code to something linear. There are 2 separate cases and I can separate one of them into a separate PR for easier review.

## Duplicate keys

This is something that was recently noticed in #539, but there had already been some work in unmerged PR's from @elidoran - #185 and #189.

The [`[].concat(a, b)`](https://github.com/ljharb/qs/blob/6bdfaf5b7c33008ff603af7772844579b42f7a3f/lib/utils.js#L290) makes copies of continually larger arrays every time `combine()` is called. There are (were) tests that check if `combine()` does not mutate input arguments, but 3086902ecf7f088d0d1803887643ac6c03d415b9 introduced new test cases that check if the first (`a`) input is mutated if it is an overflow object. I know that mutating inputs was one of the objections in #185 and #189, but I believe that the performance improvement is large enough to allow it.

This PR does not change `arrayLimit` behaviour, which is wrong (index vs length - #540) and probably should not even be there (https://github.com/ljharb/qs/issues/537#issuecomment-3787759741, #294).

This change should slightly reduce memory usage by making less copies (it reduces the number of allocations, but peak memory usage depends on GC; GHSA-6rw7-vpxm-498p mentions memory exhaustion, but it is not clear how could that happen) and makes the performance comparable to 6.14.1 with `arrayLimit: -1` (in prior versions duplicates are parsed as arrays regardless of `arrayLimit` and `parseArrays` - #543)

<details>
<summary>Memory usage change</summary>

This was tested by parsing a string with 100000 `a[]=b...b` elements, where each `b...b` string had 1000 characters - the input is 100 MB of text. Options: `{ parameterLimit: 100_000, arrayLimit: 100_000 }`

16.4.0 "Allocation" view from "Allocation timeline":

<img width="547" height="328" alt="parseQueryStringValues allocations total count 890151 (live 98345) with size 1474 MB (live 99.9 MB); combine allocations total count 3327 (live 3) with size 5.8 MB (live 168 B)" src="https://github.com/user-attachments/assets/b62e2bdb-486d-4afc-8a1b-235bb965a03c" />

This PR (f8ee66f313bb3f602668eab0a72890f51fcf0ede):

<img width="549" height="428" alt="parseQueryStringValues allocations total count 592909 (live 74896) with size 128 MB (live 76.0 MB); combine allocations total count 17 (live 5) with size 35.4 kB (live 544 B)" src="https://github.com/user-attachments/assets/9a19611d-e61e-4b58-8db6-13e026413acf" />

</details>

My benchmark results are variable, because I have a noisy environment (lots of things open, CPU frequency and core assignment not locked), but the general order of magnitude tells the difference.

| N | 6.14.1 (ms) | PR f8ee66f313bb3f602668eab0a72890f51fcf0ede (ms) |
| - | - | - |
| 100 | 0.48 | 0.20 |
| 1000 | 3.3 | 0.93 |
| 10000 | 220 | 8.7 |
| 100000 | 29576 | 68 |
| 125000 | 45686 | 78 |
| 1000000 | at least 15 minutes, Ctrl+C | call stack size exceeded |

Unfortunately, this may cause regressions with huge arrays, because `Function.apply()` pushes the arguments (all elements of array `b` in this case) to the stack. I don't think that this is a huge problem given that this happens at over 100k elements that previously would be parsed in about ~30 seconds. When exactly will this fail depends on the available size of the stack and may be hard to predict.

<details>
<summary>Benchmark code</summary>

```js
const {
  timerify,
  performance,
  PerformanceObserver,
} = require("node:perf_hooks");
const qs = require(".");

const N = 10_000;
const query = Array(N).fill("a[]=b").join("&");
// const query = Array(N).fill().map((_,i)=>`a[${i}]=b`).join("&");
// const query = Array(N).fill(`a[]=${Array(1000).fill("b").join("")}`).join("&");

function parseArray() {
    return qs.parse(query, {
        parameterLimit: N,
        arrayLimit: N
    });
}
const timedParseArray = timerify(parseArray);

const obs = new PerformanceObserver((list) => {
    for (const { name, duration } of list.getEntries()) {
        console.log(`Execution of ${name} took ${duration} ms`);
    }

    performance.clearMarks();
    performance.clearMeasures();
    obs.disconnect();
});
obs.observe({ entryTypes: ["function"] });

// warmup (not registered)
parseArray();

const arr = timedParseArray().a;
console.assert(Array.isArray(arr), "arr not an array");

```

</details>

Possible input combinations are:

- `a` is an array, `b` is not an array - `a.push(b)`
- `a` is an array, `b` is an array - `a.push.apply(b)`
- `a` is not an array, `b` is not an array - `[].concat(a, b)`
- `a` is not an array, `b` is an array - `[].concat(a, b)` - detected only [once](https://github.com/ljharb/qs/blob/6bdfaf5b7c33008ff603af7772844579b42f7a3f/test/utils.js#L161) in whole test suite, so I don't think `b.unshift(a)` makes sense

This part includes first 2 commits:

- 2870c9ce3388f10e8302741a31995c6c32bcc4ef - replace `.concat()` with `push()` if possible
- 15b1e5efb7a8406b32a51c99d951986ef8ac0cae - allow mutation of the first argument in tests that did not allow it

## Indexed arrays

Here the problem lies in `merge()` and the [`source.forEach()` call](https://github.com/ljharb/qs/blob/6bdfaf5b7c33008ff603af7772844579b42f7a3f/lib/utils.js#L119). When a string like `a[0]=b&a[1]=b&...` is parsed the `merge()` function is called with values of `target` and `source` like those below:

```plain
[ 'b' ] [ <1 empty item>, 'b' ]
[ 'b', 'b' ] [ <2 empty items>, 'b' ]
[ 'b', 'b', 'b' ] [ <3 empty items>, 'b' ]
[ 'b', 'b', 'b', 'b' ] [ <4 empty items>, 'b' ]
```

While the callback of `.forEach()` is executed only for non-empty array items in sparse arrays, it looks like it still is linear with the size of array and not the number of existing items. Since the execution time of `.forEach()` and the number of calls to `merge()` scale with N (number of elements in array with growing indices), this has O(n^2) time complexity.

The idea that I had is iterating over own properties and using the fact that for arrays they always are the indices of elements followed by `'length'`.

Benchmarks use the same code as before, but the second query is uncommented.

| N | 6.14.1 (ms) | PR f8ee66f313bb3f602668eab0a72890f51fcf0ede (ms) |
| - | - | - |
| 100 | 0.30 | 0.31 |
| 1000 | 2.8 | 3.3 |
| 5000 | 224 | 11 |
| 10000 | 911 | 22 |
| 50000 | 22683 | 106 |
| 100000 | 90571 | 221 |
| 1000000 | did not even try | 2193 |

I'm not entirely convinced if this is something worth changing, because for reasonable `arrayLimit` (affects max `.forEach()` execution time) and `parameterLimit` (affects number of `merge()` calls) values the current code performs slightly better. If there are people who change both of those limits, then this may be a real problem.

This part is in the third commit - f8ee66f313bb3f602668eab0a72890f51fcf0ede.