### PR TITLE
[Fix] encode brackets in key content to fix round-trip parsing

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -187,6 +187,7 @@ var parseObject = function (chain, val, options, valuesParsed) {
             obj = options.plainObjects ? { __proto__: null } : {};
             var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
             var decodedRoot = options.decodeDotInKeys ? cleanRoot.replace(/%2E/g, '.') : cleanRoot;
+            decodedRoot = decodedRoot.replace(/%5B/gi, '[').replace(/%5D/gi, ']');
             var index = parseInt(decodedRoot, 10);
             var isValidArrayIndex = !isNaN(index)
                 && root !== decodedRoot

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,6 +5,11 @@ var utils = require('./utils');
 var has = Object.prototype.hasOwnProperty;
 var isArray = Array.isArray;
 
+var encodedBracketOpen = /%5B/gi;
+var encodedBracketClose = /%5D/gi;
+var escapedEncodedBracketOpen = /%255B/gi;
+var escapedEncodedBracketClose = /%255D/gi;
+
 var defaults = {
     allowDots: false,
     allowEmptyArrays: false,
@@ -187,7 +192,8 @@ var parseObject = function (chain, val, options, valuesParsed) {
             obj = options.plainObjects ? { __proto__: null } : {};
             var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
             var decodedRoot = options.decodeDotInKeys ? cleanRoot.replace(/%2E/g, '.') : cleanRoot;
-            decodedRoot = decodedRoot.replace(/%5B/gi, '[').replace(/%5D/gi, ']');
+            decodedRoot = decodedRoot.replace(encodedBracketOpen, '[').replace(encodedBracketClose, ']');
+            decodedRoot = decodedRoot.replace(escapedEncodedBracketOpen, '%5B').replace(escapedEncodedBracketClose, '%5D');
             var index = parseInt(decodedRoot, 10);
             var isValidArrayIndex = !isNaN(index)
                 && root !== decodedRoot

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,8 +7,8 @@ var isArray = Array.isArray;
 
 var encodedBracketOpen = /%5B/gi;
 var encodedBracketClose = /%5D/gi;
-var escapedEncodedBracketOpen = /%255B/gi;
-var escapedEncodedBracketClose = /%255D/gi;
+var escapedEncBracketOpen = /%255B/gi;
+var escapedEncBracketClose = /%255D/gi;
 
 var defaults = {
     allowDots: false,
@@ -193,7 +193,7 @@ var parseObject = function (chain, val, options, valuesParsed) {
             var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
             var decodedRoot = options.decodeDotInKeys ? cleanRoot.replace(/%2E/g, '.') : cleanRoot;
             decodedRoot = decodedRoot.replace(encodedBracketOpen, '[').replace(encodedBracketClose, ']');
-            decodedRoot = decodedRoot.replace(escapedEncodedBracketOpen, '%5B').replace(escapedEncodedBracketClose, '%5D');
+            decodedRoot = decodedRoot.replace(escapedEncBracketOpen, '%5B').replace(escapedEncBracketClose, '%5D');
             var index = parseInt(decodedRoot, 10);
             var isValidArrayIndex = !isNaN(index)
                 && root !== decodedRoot

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -67,7 +67,7 @@ var parseValues = function parseQueryStringValues(str, options) {
     var obj = { __proto__: null };
 
     var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
-    cleanStr = cleanStr.replace(/%5B/gi, '[').replace(/%5D/gi, ']');
+    cleanStr = cleanStr.replace(encodedBracketOpen, '[').replace(encodedBracketClose, ']');
 
     var limit = options.parameterLimit === Infinity ? void undefined : options.parameterLimit;
     var parts = cleanStr.split(

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -5,6 +5,21 @@ var utils = require('./utils');
 var formats = require('./formats');
 var has = Object.prototype.hasOwnProperty;
 
+var encBracketsInContent = function encBracketsInContent(key, willBeEncoded) {
+    // When a key contains literal [ or ], pre-encode them so that the parser
+    // does not confuse them with structural brackets used for nesting.
+    // If the key will later go through the full encoder, use single encoding
+    // (%5B/%5D) since the encoder will double-encode the % to %25, producing
+    // %255B/%255D. If the key will NOT be further encoded (encodeValuesOnly),
+    // use double encoding (%255B/%255D) directly.
+    if (!(/\[|\]/).test(key)) {
+        return key;
+    }
+    var bracketOpen = willBeEncoded ? '%5B' : '%255B';
+    var bracketClose = willBeEncoded ? '%5D' : '%255D';
+    return key.replace(/\[/g, bracketOpen).replace(/\]/g, bracketClose);
+};
+
 var arrayPrefixGenerators = {
     brackets: function brackets(prefix) {
         return prefix + '[]';
@@ -171,6 +186,10 @@ var stringify = function stringify(
         }
 
         var encodedKey = allowDots && encodeDotInKeys ? String(key).replace(/\./g, '%2E') : String(key);
+        // Encode brackets in key content to prevent parser confusion with structural brackets (#513)
+        if (encoder) {
+            encodedKey = encBracketsInContent(encodedKey, !encodeValuesOnly);
+        }
         var keyPrefix = isArray(obj)
             ? typeof generateArrayPrefix === 'function' ? generateArrayPrefix(adjustedPrefix, encodedKey) : adjustedPrefix
             : adjustedPrefix + (allowDots ? '.' + encodedKey : '[' + encodedKey + ']');
@@ -317,9 +336,13 @@ module.exports = function (object, opts) {
         if (options.skipNulls && value === null) {
             continue;
         }
+        // Encode brackets in top-level key content to prevent parser confusion (#513)
+        var encodedTopKey = options.encode
+            ? encBracketsInContent(String(key), !options.encodeValuesOnly)
+            : String(key);
         pushToArray(keys, stringify(
             value,
-            key,
+            encodedTopKey,
             generateArrayPrefix,
             commaRoundTrip,
             options.allowEmptyArrays,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -5,6 +5,12 @@ var utils = require('./utils');
 var formats = require('./formats');
 var has = Object.prototype.hasOwnProperty;
 
+var hasBracketOrEncoded = /\[|\]|%5B|%5D/i;
+var openBracket = /\[/g;
+var closeBracket = /\]/g;
+var encodedOpenBracket = /%5B/gi;
+var encodedCloseBracket = /%5D/gi;
+
 var encBracketsInContent = function encBracketsInContent(key, willBeEncoded) {
     // When a key contains literal [ or ], pre-encode them so that the parser
     // does not confuse them with structural brackets used for nesting.
@@ -12,12 +18,21 @@ var encBracketsInContent = function encBracketsInContent(key, willBeEncoded) {
     // (%5B/%5D) since the encoder will double-encode the % to %25, producing
     // %255B/%255D. If the key will NOT be further encoded (encodeValuesOnly),
     // use double encoding (%255B/%255D) directly.
-    if (!(/\[|\]/).test(key)) {
+    //
+    // We also pre-encode any existing %5B/%5D text in the key so that
+    // literal percent-encoded bracket sequences survive the round-trip
+    // through the parser's %5B/%5D decoding step.
+    if (!hasBracketOrEncoded.test(key)) {
         return key;
     }
+    // First, escape any existing %5B/%5D sequences to avoid collision
+    var escaped = key
+        .replace(encodedOpenBracket, willBeEncoded ? '%255B' : '%25255B')
+        .replace(encodedCloseBracket, willBeEncoded ? '%255D' : '%25255D');
+    // Then, encode actual bracket characters
     var bracketOpen = willBeEncoded ? '%5B' : '%255B';
     var bracketClose = willBeEncoded ? '%5D' : '%255D';
-    return key.replace(/\[/g, bracketOpen).replace(/\]/g, bracketClose);
+    return escaped.replace(openBracket, bracketOpen).replace(closeBracket, bracketClose);
 };
 
 var arrayPrefixGenerators = {
@@ -328,6 +343,7 @@ module.exports = function (object, opts) {
         objKeys.sort(options.sort);
     }
 
+    var encoder = options.encode ? options.encoder : null;
     var sideChannel = getSideChannel();
     for (var i = 0; i < objKeys.length; ++i) {
         var key = objKeys[i];
@@ -337,7 +353,7 @@ module.exports = function (object, opts) {
             continue;
         }
         // Encode brackets in top-level key content to prevent parser confusion (#513)
-        var encodedTopKey = options.encode
+        var encodedTopKey = encoder
             ? encBracketsInContent(String(key), !options.encodeValuesOnly)
             : String(key);
         pushToArray(keys, stringify(
@@ -349,7 +365,7 @@ module.exports = function (object, opts) {
             options.strictNullHandling,
             options.skipNulls,
             options.encodeDotInKeys,
-            options.encode ? options.encoder : null,
+            encoder,
             options.filter,
             options.sort,
             options.allowDots,

--- a/test/parse.js
+++ b/test/parse.js
@@ -1699,5 +1699,36 @@ test('mixed array and object notation', function (t) {
         st.end();
     });
 
+    t.test('decodes encoded brackets in key content (#513)', function (st) {
+        // %5B/%5D in segment content should be decoded to [ and ]
+        st.deepEqual(
+            qs.parse('a%5Bb%255Bc%255D%5D=d'),
+            { a: { 'b[c]': 'd' } },
+            'decodes double-encoded brackets in nested key content'
+        );
+
+        // top-level key with double-encoded brackets
+        st.deepEqual(
+            qs.parse('a%255Bb%255D=c'),
+            { 'a[b]': 'c' },
+            'decodes double-encoded brackets in top-level key'
+        );
+
+        // encodeValuesOnly-style input (structural brackets literal, content double-encoded)
+        st.deepEqual(
+            qs.parse('a[b%255Bc%255D]=d'),
+            { a: { 'b[c]': 'd' } },
+            'decodes double-encoded brackets in key content with literal structural brackets'
+        );
+
+        // issue #513: key content with JSON-like brackets
+        st.deepEqual(
+            qs.parse('buttons%5Bcommands%7C%7B%22orders%22%3A%255B%2247441%22%255D%7D%5D=Unisci%20ordini'),
+            { buttons: { 'commands|{"orders":["47441"]}': 'Unisci ordini' } },
+            'correctly parses key content with JSON-like brackets'
+        );
+        st.end();
+    });
+
     t.end();
 });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1338,6 +1338,84 @@ test('stringifies empty keys', function (t) {
         st.end();
     });
 
+    t.test('encodes brackets in key content for round-trip safety (#513)', function (st) {
+        // nested key with brackets in content
+        st.equal(
+            qs.stringify({ a: { 'b[c]': 'd' } }),
+            'a%5Bb%255Bc%255D%5D=d',
+            'encodes nested key containing brackets with default encoding'
+        );
+
+        // flat key with brackets in content
+        st.equal(
+            qs.stringify({ 'a[b]': 'c' }),
+            'a%255Bb%255D=c',
+            'encodes top-level key containing brackets with default encoding'
+        );
+
+        // round-trip: nested key with brackets
+        var obj1 = { a: { 'b[c]': 'd' } };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj1)),
+            obj1,
+            'round-trips nested key containing brackets'
+        );
+
+        // round-trip: flat key with brackets (issue #513 example)
+        var obj2 = { 'my name|{"data":["one","two","three"]}': 'value' };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj2)),
+            obj2,
+            'round-trips flat key containing brackets'
+        );
+
+        // round-trip with encodeValuesOnly
+        st.equal(
+            qs.stringify({ a: { 'b[c]': 'd' } }, { encodeValuesOnly: true }),
+            'a[b%255Bc%255D]=d',
+            'encodes nested key containing brackets with encodeValuesOnly'
+        );
+
+        var obj3 = { a: { 'b[c]': 'd' } };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj3, { encodeValuesOnly: true })),
+            obj3,
+            'round-trips nested key containing brackets with encodeValuesOnly'
+        );
+
+        // round-trip: original issue example (buttons with JSON in key)
+        var obj4 = { buttons: { 'commands.identifier|{"orders":["47441","47440"]}': 'Unisci ordini' } };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj4)),
+            obj4,
+            'round-trips issue #513 example with nested brackets in key content'
+        );
+
+        // keys without brackets should be unaffected
+        st.equal(
+            qs.stringify({ a: { b: 'c' } }),
+            'a%5Bb%5D=c',
+            'keys without brackets are unaffected'
+        );
+
+        // round-trip with allowDots
+        var obj5 = { a: { 'b[c]': 'd' } };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj5, { allowDots: true }), { allowDots: true }),
+            obj5,
+            'round-trips nested key containing brackets with allowDots'
+        );
+
+        // encode: false should not encode brackets
+        st.equal(
+            qs.stringify({ a: { 'b[c]': 'd' } }, { encode: false }),
+            'a[b[c]]=d',
+            'does not encode brackets in key content when encode is false'
+        );
+
+        st.end();
+    });
+
     t.test('parses input containing percent-encoded bracket text without mangling', function (st) {
         st.deepEqual(qs.parse('a%25255Bb=c'), { 'a%255Bb': 'c' }, 'a%25255Bb decodes to a%255Bb, not a%5Bb');
         st.deepEqual(qs.parse('a%25255Db=c'), { 'a%255Db': 'c' }, 'a%25255Db decodes to a%255Db, not a%5Db');

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1413,6 +1413,36 @@ test('stringifies empty keys', function (t) {
             'does not encode brackets in key content when encode is false'
         );
 
+        // round-trip: key containing literal %5B text (should not be mangled)
+        var obj6 = { 'a%5Bb': 'c' };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj6)),
+            obj6,
+            'round-trips flat key containing literal %5B text'
+        );
+
+        var obj7 = { a: { 'b%5Bc': 'd' } };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj7)),
+            obj7,
+            'round-trips nested key containing literal %5B text'
+        );
+
+        var obj8 = { a: { 'b%5Bc%5D': 'd' } };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj8)),
+            obj8,
+            'round-trips nested key containing literal %5B and %5D text'
+        );
+
+        // round-trip with encodeValuesOnly: key containing literal %5B text
+        var obj9 = { a: { 'b%5Bc': 'd' } };
+        st.deepEqual(
+            qs.parse(qs.stringify(obj9, { encodeValuesOnly: true })),
+            obj9,
+            'round-trips nested key containing literal %5B text with encodeValuesOnly'
+        );
+
         st.end();
     });
 


### PR DESCRIPTION
When object keys contain literal `[` or `]` characters (e.g. JSON-like strings or other data embedded in property names), `qs.stringify` would produce output that `qs.parse` could not correctly parse back, because the parser confused content brackets with the structural brackets used for nesting (`a[b]=c`).

This patch pre-encodes `[` and `]` inside key content before wrapping it with structural brackets during stringification. On the parse side, the encoded brackets are decoded back after structural splitting is done.

**Before:**
```js
var obj = { buttons: { 'cmd|{"orders":["47441","47440"]}': 'merge' } };
qs.parse(qs.stringify(obj));
// => { 'buttons[cmd|{"orders":': { '"47441","47440"': 'merge' } }
```

**After:**
```js
var obj = { buttons: { 'cmd|{"orders":["47441","47440"]}': 'merge' } };
qs.parse(qs.stringify(obj));
// => { buttons: { 'cmd|{"orders":["47441","47440"]}': 'merge' } }
```

Round-trips work with default encoding, `encodeValuesOnly`, and `allowDots`. When `encode: false`, no encoding is applied (brackets pass through as-is, matching existing behavior).

Fixes #513