### PR TITLE
[Fix] `stringify`: skip null/undefined filter-array entries instead of crashing in `encoder`

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -312,6 +312,17 @@ module.exports = function (object, opts) {
     var sideChannel = getSideChannel();
     for (var i = 0; i < objKeys.length; ++i) {
         var key = objKeys[i];
+
+        // Skip null/undefined entries when objKeys came from a filter array.
+        // Without this guard, the raw key is passed as the prefix to the
+        // recursive stringify call below, and encoder(null).length throws.
+        // Object.keys never yields null/undefined, so this only affects
+        // user-supplied filter arrays — matching JSON.stringify replacer
+        // semantics, which silently ignore non-string/number entries.
+        if (typeof key === 'undefined' || key === null) {
+            continue;
+        }
+
         var value = obj[key];
 
         if (options.skipNulls && value === null) {

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -312,6 +312,11 @@ module.exports = function (object, opts) {
     var sideChannel = getSideChannel();
     for (var i = 0; i < objKeys.length; ++i) {
         var key = objKeys[i];
+
+        if (typeof key === 'undefined' || key === null) {
+            continue;
+        }
+
         var value = obj[key];
 
         if (options.skipNulls && value === null) {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -825,6 +825,35 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('skips null/undefined entries in filter=array', function (st) {
+        st.doesNotThrow(
+            function () { qs.stringify({ a: 'b', 'undefined': 'x' }, { filter: ['a', undefined] }); },
+            'does not pass a raw undefined filter entry to the encoder'
+        );
+        st.doesNotThrow(
+            function () { qs.stringify({ a: 'b', 'null': 'x' }, { filter: ['a', null] }); },
+            'does not pass a raw null filter entry to the encoder'
+        );
+
+        st.equal(
+            qs.stringify({ a: 'b', 'undefined': 'x', c: 'd' }, { filter: ['a', undefined, 'c'] }),
+            'a=b&c=d',
+            'undefined filter entry is skipped, remaining keys are kept'
+        );
+        st.equal(
+            qs.stringify({ a: 'b', 'null': 'x', c: 'd' }, { filter: ['a', null, 'c'] }),
+            'a=b&c=d',
+            'null filter entry is skipped, remaining keys are kept'
+        );
+        st.equal(
+            qs.stringify({ a: 'b', 'null': 'x' }, { filter: [null] }),
+            '',
+            'filter array containing only null yields empty string'
+        );
+
+        st.end();
+    });
+
     t.test('supports custom representations when filter=function', function (st) {
         var calls = 0;
         var obj = { a: 'b', c: 'd', e: { f: new Date(1257894000000) } };

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -825,6 +825,35 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('skips null/undefined entries in filter=array', function (st) {
+        st.doesNotThrow(
+            function () { qs.stringify({ a: 'b', undefined: 'x' }, { filter: ['a', undefined] }); },
+            'does not pass a raw undefined filter entry to the encoder'
+        );
+        st.doesNotThrow(
+            function () { qs.stringify({ a: 'b', 'null': 'x' }, { filter: ['a', null] }); },
+            'does not pass a raw null filter entry to the encoder'
+        );
+
+        st.equal(
+            qs.stringify({ a: 'b', undefined: 'x', c: 'd' }, { filter: ['a', undefined, 'c'] }),
+            'a=b&c=d',
+            'undefined filter entry is skipped, remaining keys are kept'
+        );
+        st.equal(
+            qs.stringify({ a: 'b', 'null': 'x', c: 'd' }, { filter: ['a', null, 'c'] }),
+            'a=b&c=d',
+            'null filter entry is skipped, remaining keys are kept'
+        );
+        st.equal(
+            qs.stringify({ a: 'b', 'null': 'x' }, { filter: [null] }),
+            '',
+            'filter array containing only null yields empty string'
+        );
+
+        st.end();
+    });
+
     t.test('supports custom representations when filter=function', function (st) {
         var calls = 0;
         var obj = { a: 'b', c: 'd', e: { f: new Date(1257894000000) } };


### PR DESCRIPTION
When `filter` is an array, its elements become `objKeys` directly and the top-level loop passes each entry as the recursive `prefix` argument without coercion.  A `null` or `undefined` entry reached `utils.encode` as the `str` argument and `str.length` threw `TypeError`.

The crash requires two conditions to align: the filter array must contain `null`/`undefined`, and the object being stringified must have a literal `'null'`/`'undefined'` property (otherwise `obj[key]` is `undefined` and the typeof-undefined early-return at stringify.js:137 fires before the encoder is called).  Both are reachable from an attacker controlled input in applications that stringify user-submitted JSON with user-selected fields.

Fix this up by skipping `null`/`undefined` filter entries at the top-level loop.  This matches `JSON.stringify` replacer-array semantics, which silently ignore non-string/non-number entries.  `Object.keys` never yields `null`/`undefined`, so the guard only affects user-supplied filter arrays.  The inner recursive loop already coerces `key` via `String()` when building `keyPrefix`, so it never passes a raw `null` to the encoder.