### PR TITLE
[Fix] `stringify`: apply `formatter` to encoded key under `strictNullHandling`

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -118,7 +118,7 @@ var stringify = function stringify(
 
     if (obj === null) {
         if (strictNullHandling) {
-            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, 'key', format) : prefix;
+            return formatter(encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, 'key', format) : prefix);
         }
 
         obj = '';

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1140,6 +1140,28 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('strictNullHandling: applies the formatter to the encoded key (RFC1738)', function (st) {
+        st.equal(
+            qs.stringify(
+                { 'a b': null, 'c d': 'e f' },
+                { strictNullHandling: false, format: 'RFC1738' }
+            ),
+            'a+b=&c+d=e+f',
+            'without: as expected'
+        );
+
+        st.equal(
+            qs.stringify(
+                { 'a b': null, 'c d': 'e f' },
+                { strictNullHandling: true, format: 'RFC1738' }
+            ),
+            'a+b&c+d=e+f',
+            'with: as expected'
+        );
+
+        st.end();
+    });
+
     t.test('throws if an invalid charset is specified', function (st) {
         st['throws'](function () {
             qs.stringify({ a: 'b' }, { charset: 'foobar' });


### PR DESCRIPTION
Previously the null branch returned the raw `encoder(prefix, ...)` output (or raw `prefix`) without running it through `formatter`. With `format: 'RFC1738'` this caused keys containing spaces to serialize as `%20` in strict-null mode while the normal primitive path produced `+`, yielding inconsistent output for the same key.