### PR TITLE
[Fix] `stringify`: use configured `delimiter` after `charsetSentinel`

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -350,10 +350,10 @@ module.exports = function (object, opts) {
     if (options.charsetSentinel) {
         if (options.charset === 'iso-8859-1') {
             // encodeURIComponent('&#10003;'), the "numeric entity" representation of a checkmark
-            prefix += 'utf8=%26%2310003%3B&';
+            prefix += 'utf8=%26%2310003%3B' + options.delimiter;
         } else {
             // encodeURIComponent('✓')
-            prefix += 'utf8=%E2%9C%93&';
+            prefix += 'utf8=%E2%9C%93' + options.delimiter;
         }
     }
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1197,6 +1197,12 @@ test('stringify()', function (t) {
             'adds the right sentinel when instructed to and the charset is iso-8859-1'
         );
 
+        st.equal(
+            qs.stringify({ a: 1, b: 2 }, { charsetSentinel: true, delimiter: ';' }),
+            'utf8=%E2%9C%93;a=1;b=2',
+            'uses the configured delimiter after the sentinel'
+        );
+
         st.end();
     });
 


### PR DESCRIPTION
The `utf8=...` charset sentinel was followed by a hardcoded `&`, ignoring `options.delimiter`. With any non-`&` delimiter the output mixed delimiters (e.g. `utf8=%E2%9C%93&a=1;b=2`), breaking self round-tripping. Emit the configured delimiter instead, and add a regression test.