### PR TITLE
fix: consistent array overflow handling regardless of arrayLimit value

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,7 @@ var merge = function merge(target, source, options) {
     if (typeof source !== 'object' && typeof source !== 'function') {
         if (isArray(target)) {
             var nextIndex = target.length;
-            if (options && typeof options.arrayLimit === 'number' && nextIndex > options.arrayLimit) {
+            if (options && typeof options.arrayLimit === 'number' && nextIndex >= options.arrayLimit) {
                 return markOverflow(arrayToObject(target.concat(source), options), nextIndex);
             }
             target[nextIndex] = source;
@@ -114,7 +114,7 @@ var merge = function merge(target, source, options) {
             return markOverflow(result, getMaxIndex(source) + 1);
         }
         var combined = [target].concat(source);
-        if (options && typeof options.arrayLimit === 'number' && combined.length > options.arrayLimit) {
+        if (options && typeof options.arrayLimit === 'number' && combined.length >= options.arrayLimit) {
             return markOverflow(arrayToObject(combined, options), combined.length - 1);
         }
         return combined;

--- a/test/parse.js
+++ b/test/parse.js
@@ -555,6 +555,73 @@ test('parse()', function (t) {
         st.end();
     });
 
+    t.test('consistent overflow handling regardless of arrayLimit value', function (st) {
+        st.deepEqual(
+            qs.parse('a[]=b&a[1]=c&a=d', { arrayLimit: -1 }),
+            { a: { 0: 'b', 1: 'c', 2: 'd' } },
+            'mixed array notation with arrayLimit -1 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a[]=b&a[1]=c&a=d', { arrayLimit: 0 }),
+            { a: { 0: 'b', 1: 'c', 2: 'd' } },
+            'mixed array notation with arrayLimit 0 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a[]=b&a[1]=c&a=d', { arrayLimit: 1 }),
+            { a: { 0: 'b', 1: 'c', 2: 'd' } },
+            'mixed array notation with arrayLimit 1 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a[]=b&a[1]=c&a=d', { arrayLimit: 2 }),
+            { a: { 0: 'b', 1: 'c', 2: 'd' } },
+            'mixed array notation with arrayLimit 2 produces object'
+        );
+
+        st.deepEqual(
+            qs.parse('a[0]=c&a=b', { arrayLimit: -1 }),
+            { a: { 0: 'c', 1: 'b' } },
+            'index + plain with arrayLimit -1 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a[0]=c&a=b', { arrayLimit: 0 }),
+            { a: { 0: 'c', 1: 'b' } },
+            'index + plain with arrayLimit 0 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a[0]=c&a=b', { arrayLimit: 1 }),
+            { a: { 0: 'c', 1: 'b' } },
+            'index + plain with arrayLimit 1 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a[0]=c&a=b', { arrayLimit: 2 }),
+            { a: { 0: 'c', 1: 'b' } },
+            'index + plain with arrayLimit 2 produces object'
+        );
+
+        st.deepEqual(
+            qs.parse('a=b&a[0]=c', { arrayLimit: -1 }),
+            { a: { 0: 'b', 1: 'c' } },
+            'plain + index with arrayLimit -1 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a=b&a[0]=c', { arrayLimit: 0 }),
+            { a: { 0: 'b', 1: 'c' } },
+            'plain + index with arrayLimit 0 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a=b&a[0]=c', { arrayLimit: 1 }),
+            { a: { 0: 'b', 1: 'c' } },
+            'plain + index with arrayLimit 1 produces object'
+        );
+        st.deepEqual(
+            qs.parse('a=b&a[0]=c', { arrayLimit: 2 }),
+            { a: { 0: 'b', 1: 'c' } },
+            'plain + index with arrayLimit 2 produces object'
+        );
+
+        st.end();
+    });
+
     t.test('allows disabling array parsing', function (st) {
         var indices = qs.parse('a[0]=b&a[1]=c', { parseArrays: false });
         st.deepEqual(indices, { a: { 0: 'b', 1: 'c' } });


### PR DESCRIPTION
## Summary
Fix inconsistent array overflow handling when `arrayLimit` is exceeded with mixed array notation.

## Problem
Parsing `a[]=b&a[1]=c&a=d` produces different results depending on the `arrayLimit` value (-1, 0, 1), even though the limit is exceeded in all cases. For example, `a[0]=c&a=b` with `arrayLimit: 1` produced `["c","b"]` (array) while `arrayLimit: 0` and `-1` both produced `{0:"c", 1:"b"}` (object).

The overflow detection in `lib/utils.js` `merge` function used `>` (strict greater-than) instead of `>=` when checking whether appending to an array would exceed the limit, allowing arrays at exactly the boundary to grow past the limit.

## Solution
Changed the overflow boundary check in two places in `utils.js` `merge` from `>` to `>=`:
1. When merging a non-object source into an array target (line 78)
2. When merging a non-object target with an array/object source (line 117)

This ensures that when an array is already at its maximum allowed length (`arrayLimit`), adding more elements triggers overflow conversion to an object, consistent with how lower `arrayLimit` values behave.

## Test Plan
- [x] `a[]=b&a[1]=c&a=d` with arrayLimit -1, 0, 1 all produce `{0:'b', 1:'c', 2:'d'}`
- [x] `a[0]=c&a=b` with arrayLimit -1, 0, 1 all produce `{0:'c', 1:'b'}`
- [x] `a=b&a[0]=c` with arrayLimit -1, 0, 1 all produce `{0:'b', 1:'c'}`
- [x] Normal array parsing within limits still works
- [x] Existing test suite passes (929/929) with 100% coverage

Fixes #546