### PR TITLE
[Fix] `utils`: respect encoding of surrogate pairs across chunks

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -226,6 +226,13 @@ var encode = function encode(str, defaultEncoder, charset, kind, format) {
     var out = '';
     for (var j = 0; j < string.length; j += limit) {
         var segment = string.length >= limit ? string.slice(j, j + limit) : string;
+        if (j + limit < string.length) {
+            var last = segment.charCodeAt(segment.length - 1);
+            if (last >= 0xD800 && last <= 0xDBFF) {
+                segment = segment.slice(0, -1);
+                j -= 1;
+            }
+        }
         var arr = [];
 
         for (var i = 0; i < segment.length; ++i) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -372,6 +372,79 @@ test('encode', function (t) {
         'encodes a long string'
     );
 
+    var boundary = '';
+    var expected = '';
+    for (var j = 0; j < 1023; j++) {
+        boundary += 'a';
+        expected += 'a';
+    }
+    boundary += '😀';
+    expected += '%F0%9F%98%80';
+
+    t.equal(
+        utils.encode(boundary),
+        expected,
+        'encodes a surrogate pair split across long-string chunks'
+    );
+
+    var laterBoundary = '';
+    var laterExpected = '';
+    for (var k = 0; k < 2047; k++) {
+        laterBoundary += 'a';
+        laterExpected += 'a';
+    }
+    laterBoundary += '😀';
+    laterExpected += '%F0%9F%98%80';
+
+    t.equal(
+        utils.encode(laterBoundary),
+        laterExpected,
+        'encodes a surrogate pair split across a later chunk boundary'
+    );
+
+    var twoPairs = '';
+    for (k = 0; k < 1023; k++) {
+        twoPairs += 'a';
+    }
+    twoPairs += '😀';
+    for (k = 0; k < 1022; k++) {
+        twoPairs += 'b';
+    }
+    twoPairs += '😀';
+
+    t.equal(
+        (utils.encode(twoPairs).match(/%F0%9F%98%80/g) || []).length,
+        2,
+        'encodes two surrogate pairs each split across a chunk boundary'
+    );
+
+    var roundTrip = '';
+    for (k = 0; k < 1023; k++) {
+        roundTrip += 'a';
+    }
+    roundTrip += '😀';
+
+    t.equal(
+        decodeURIComponent(utils.encode(roundTrip)),
+        roundTrip,
+        'a boundary-split surrogate pair round-trips through decodeURIComponent'
+    );
+
+    var loneBoundary = '';
+    var loneExpected = '';
+    for (k = 0; k < 1023; k++) {
+        loneBoundary += 'a';
+        loneExpected += 'a';
+    }
+    loneBoundary += '\uD83DX';
+    loneExpected += '%F0%9F%91%98';
+
+    t.equal(
+        utils.encode(loneBoundary),
+        loneExpected,
+        'a lone high surrogate at a chunk boundary encodes the same as mid-chunk'
+    );
+
     t.equal(
         utils.encode('\x28\x29'),
         '%28%29',


### PR DESCRIPTION
### Summary
- avoid splitting UTF-16 surrogate pairs across the encoder's 1024-code-unit chunks
- add a regression test for a surrogate pair that lands on the chunk boundary
- rebuild the browser bundle

### Bug
`utils.encode` chunks long strings before percent-encoding. When a high surrogate lands at the end of a chunk and the low surrogate is in the next chunk, the pair is encoded as two invalid code points instead of one Unicode character.

Example before this change:

```js
var s = Array(1024).join('a') + '😀';
qs.stringify({ x: s }); // ended with %F0%9F%90%80%F2%90%80%80
```

After this change, the output correctly ends with `%F0%9F%98%80`.

### Tests
- `npx tape "test/**/*.js"`
- `npx tape test/utils.js`
- `npx eclint check lib/utils.js test/utils.js`
- `npx eslint lib/utils.js test/utils.js` (no errors; existing `no-continue` warnings remain)
- verified `dist/qs.js` with the boundary reproduction