### PR TITLE
[Fix] `stringify`: encode keys when `allowEmptyArrays` is set

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -159,7 +159,7 @@ var stringify = function stringify(
     var adjustedPrefix = commaRoundTrip && isArray(obj) && obj.length === 1 ? encodedPrefix + '[]' : encodedPrefix;
 
     if (allowEmptyArrays && isArray(obj) && obj.length === 0) {
-        return adjustedPrefix + '[]';
+        return (encoder && !encodeValuesOnly ? formatter(encoder(adjustedPrefix, defaults.encoder, charset, 'key', format)) : adjustedPrefix) + '[]';
     }
 
     for (var j = 0; j < objKeys.length; ++j) {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -292,6 +292,31 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('should encode the key of an empty array when allowEmptyArrays is set', function (st) {
+        st.equal(
+            qs.stringify({ 'a b': [] }, { allowEmptyArrays: true }),
+            'a%20b[]',
+            'default (RFC3986) percent-encodes the space in the key'
+        );
+        st.equal(
+            qs.stringify({ 'a b': [] }, { allowEmptyArrays: true, format: 'RFC1738' }),
+            'a+b[]',
+            'RFC1738 encodes the space in the key as a plus'
+        );
+        st.equal(
+            qs.stringify({ 'a b': [] }, { allowEmptyArrays: true, encodeValuesOnly: true }),
+            'a b[]',
+            'encodeValuesOnly leaves the key unencoded'
+        );
+        st.equal(
+            qs.stringify({ 'a b': [] }, { allowEmptyArrays: true, encode: false }),
+            'a b[]',
+            'encode: false leaves the key unencoded'
+        );
+
+        st.end();
+    });
+
     t.test('should throw when allowEmptyArrays is not of type boolean', function (st) {
         st['throws'](
             function () { qs.stringify({ a: [], b: 'zz' }, { allowEmptyArrays: 'foobar' }); },


### PR DESCRIPTION
When `allowEmptyArrays: true` is set, an empty-array key is emitted via an early return that concatenates the raw prefix with `[]`, bypassing the encoder and formatter that every other key path runs through. As a result keys that require encoding are emitted unencoded (and invalid):

```js
qs.stringify({ 'a b': [] }, { allowEmptyArrays: true });
// before: 'a b[]'   (raw space — invalid)
// after:  'a%20b[]'
```

This is the same class of bug as #554 (`strictNullHandling` not applying the formatter to the encoded key, sibling code branch just above). The fix mirrors that one: wrap the prefix in `formatter(encoder(prefix, defaults.encoder, charset, 'key', format))` when an encoder is present and we're not in `encodeValuesOnly` mode — matching the existing `strictNullHandling` line exactly.

### Behavior
- default (RFC3986): `{ 'a b': [] }` → `a%20b[]`
- `format: 'RFC1738'`: → `a+b[]`
- `encodeValuesOnly: true`: → `a b[]` (key left raw, as expected)
- `encode: false`: → `a b[]` (unchanged)
- keys that need no encoding (e.g. `foo`) are unchanged, so existing tests/README stay valid.

### Tests
Added a regression test (`should encode the key of an empty array when allowEmptyArrays is set`) covering the default, RFC1738, `encodeValuesOnly`, and `encode: false` cases. Full suite green (941 tests).
