### PR TITLE
[Fix] `parse`: interpret astral numeric entities via `String.fromCodePoint`

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -32,7 +32,11 @@ var defaults = {
 
 var interpretNumericEntities = function (str) {
     return str.replace(/&#(\d+);/g, function ($0, numberStr) {
-        return String.fromCharCode(parseInt(numberStr, 10));
+        var codePoint = parseInt(numberStr, 10);
+        // `String.fromCharCode` truncates to 16 bits, mangling astral code points
+        // (e.g. emoji, `&#128512;`); `String.fromCodePoint` handles the full range
+        // but throws on values above the Unicode maximum, so leave those untouched.
+        return codePoint > 0x10FFFF ? $0 : String.fromCodePoint(codePoint);
     });
 };
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -1117,6 +1117,7 @@ test('parse()', function (t) {
     var urlEncodedOSlashInUtf8 = '%C3%B8';
     var urlEncodedNumCheckmark = '%26%2310003%3B';
     var urlEncodedNumSmiley = '%26%239786%3B';
+    var urlEncodedNumGrinning = '%26%23128512%3B'; // &#128512; -> U+1F600 (astral)
 
     t.test('prefers an utf-8 charset specified by the utf8 sentinel to a default charset of iso-8859-1', function (st) {
         st.deepEqual(qs.parse('utf8=' + urlEncodedCheckmarkInUtf8 + '&' + urlEncodedOSlashInUtf8 + '=' + urlEncodedOSlashInUtf8, { charsetSentinel: true, charset: 'iso-8859-1' }), { ø: 'ø' });
@@ -1150,6 +1151,24 @@ test('parse()', function (t) {
 
     t.test('interprets numeric entities in iso-8859-1 when `interpretNumericEntities`', function (st) {
         st.deepEqual(qs.parse('foo=' + urlEncodedNumSmiley, { charset: 'iso-8859-1', interpretNumericEntities: true }), { foo: '☺' });
+        st.end();
+    });
+
+    t.test('interprets astral (> U+FFFF) numeric entities in iso-8859-1 when `interpretNumericEntities`', function (st) {
+        var grinning = String.fromCodePoint(0x1F600); // 😀
+        st.deepEqual(
+            qs.parse('foo=' + urlEncodedNumGrinning, { charset: 'iso-8859-1', interpretNumericEntities: true }),
+            { foo: grinning },
+            'a numeric entity above U+FFFF round-trips to the correct code point'
+        );
+
+        // out-of-range code points (> U+10FFFF) must not throw; left as the literal entity
+        st.deepEqual(
+            qs.parse('foo=%26%231114112%3B', { charset: 'iso-8859-1', interpretNumericEntities: true }),
+            { foo: '&#1114112;' },
+            'an out-of-range numeric entity is left untouched instead of throwing'
+        );
+
         st.end();
     });
 


### PR DESCRIPTION
## Bug

With `interpretNumericEntities: true` (in `iso-8859-1` charset), a numeric character reference for an **astral** code point — anything above U+FFFF, i.e. emoji and many CJK-extension characters — is decoded into the **wrong** character:

```js
qs.parse('a=%26%23128512%3B', { charset: 'iso-8859-1', interpretNumericEntities: true });
// %26%23128512%3B === encodeURIComponent('&#128512;'), the reference for 😀 (U+1F600)

// actual:   { a: '' }   ← a single, wrong BMP char
// expected: { a: '😀' }       ← U+1F600
```

## Cause

`interpretNumericEntities` uses `String.fromCharCode`:

```js
return str.replace(/&#(\d+);/g, function ($0, numberStr) {
    return String.fromCharCode(parseInt(numberStr, 10));
});
```

`String.fromCharCode` operates on UTF-16 **code units** (0 – 0xFFFF) and truncates larger values to 16 bits. For `&#128512;`, `128512 & 0xFFFF === 0xF600`, so it yields `''` (a lone Private-Use-Area char) rather than the surrogate pair for U+1F600. BMP references (e.g. the existing `&#9786;` → ☺, and the `&#10003;` checkmark used by the charset sentinel) happen to be unaffected because they already fit in 16 bits.

## Fix

Use `String.fromCodePoint`, which produces the correct surrogate pair across the full Unicode range. `fromCodePoint` throws a `RangeError` for values above the Unicode maximum (U+10FFFF), which `fromCharCode` never did — so guard against that and leave out-of-range entities (`&#1114112;`, `&#9999999999;`, …) as the literal text instead of throwing. For valid BMP references the output is byte-for-byte identical to before.

```js
var codePoint = parseInt(numberStr, 10);
return codePoint > 0x10FFFF ? $0 : String.fromCodePoint(codePoint);
```

## Tests

Added a case under the existing `interpretNumericEntities` tests in `test/parse.js`:

- `&#128512;` (U+1F600) round-trips to 😀.
- An out-of-range reference (`&#1114112;`) is left untouched and does **not** throw.

Verification:

- `npx tape test/parse.js` — 404 passing (was 402 + 2 failing without the fix; the two new assertions fail on `master` and pass with the change).
- `npm run tests-only` — 939 passing.
- `npm run lint` — 0 errors (pre-existing warnings only, none on the changed lines).

`structuredClone`/the WHATWG URL encoder and browsers all resolve `&#128512;` to U+1F600; this brings `qs` in line.
