### PR TITLE
[Fix] `stringify`: stop re-encoding structural separator dots when `encodeDotInKeys` is set

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -154,7 +154,7 @@ var stringify = function stringify(
         objKeys = sort ? keys.sort(sort) : keys;
     }
 
-    var encodedPrefix = encodeDotInKeys ? String(prefix).replace(/\./g, '%2E') : String(prefix);
+    var encodedPrefix = String(prefix);
 
     var adjustedPrefix = commaRoundTrip && isArray(obj) && obj.length === 1 ? encodedPrefix + '[]' : encodedPrefix;
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -212,54 +212,22 @@ test('stringify()', function (t) {
         st.end();
     });
 
-    // Characterization of the CURRENT (buggy) behavior: with `allowDots` + `encodeDotInKeys`,
-    // `stringify` percent-encodes the structural `.` separators that `allowDots` inserts between
-    // nested keys, not just the literal dots inside a key, which breaks the stringify -> parse
-    // round-trip. These assertions pin that behavior so it cannot change silently: the fix in
-    // https://github.com/ljharb/qs/pull/564 changes every output below, so landing that fix MUST
-    // update this test (that is the point — it forces the behavior change to be explicit).
-    t.test('[characterization] encodeDotInKeys currently over-encodes structural separator dots (pre-#564)', function (st) {
+    t.test('does not encode the structural separator dots between nested keys when encodeDotInKeys and allowDots are provided', function (st) {
         st.equal(
-            qs.stringify({ a: { b: { c: 'd' } } }, { allowDots: true, encodeDotInKeys: true }),
-            'a%252Eb.c=d',
-            'over-encodes the a->b separator (#564: should become a.b.c=d)'
+            qs.stringify(
+                { a: { b: { c: 'd' } } },
+                { allowDots: true, encodeDotInKeys: true }
+            ),
+            'a.b.c=d',
+            'no key contains a literal dot, so encodeDotInKeys is a no-op on the separators'
         );
         st.equal(
-            qs.stringify({ a: { b: { c: { d: 'e' } } } }, { allowDots: true, encodeDotInKeys: true }),
-            'a%252Eb%252Ec.d=e',
-            'clobbers every separator but the last (#564: should become a.b.c.d=e)'
-        );
-        st.equal(
-            qs.stringify({ 'a.b': { c: { d: 'e' } } }, { allowDots: true, encodeDotInKeys: true }),
-            'a%252Eb%252Ec.d=e',
-            'top-level dotted key: deeper separators also get encoded (#564: should become a%252Eb.c.d=e)'
-        );
-        st.equal(
-            qs.stringify({ a: { 'b.c': { d: 'e' } } }, { allowDots: true, encodeDotInKeys: true }),
-            'a%252Eb%252Ec.d=e',
-            'nested dotted key + object value: the separator around it is encoded (#564: should become a.b%252Ec.d=e)'
-        );
-        st.equal(
-            qs.stringify({ a: { b: { 'c.d': { e: 'f' } } } }, { allowDots: true, encodeDotInKeys: true }),
-            'a%252Eb%252Ec%252Ed.e=f',
-            'deeply nested dotted key: all separators encoded (#564: should become a.b.c%252Ed.e=f)'
-        );
-
-        st.equal(
-            qs.stringify({ a: { b: [1, 2] } }, { allowDots: true, encodeDotInKeys: true }),
-            'a%252Eb%5B0%5D=1&a%252Eb%5B1%5D=2',
-            'array value under nested keys: separator encoded (#564: should become a.b%5B0%5D=1&a.b%5B1%5D=2)'
-        );
-        st.equal(
-            qs.stringify({ a: { 'b.c': [1, 2] } }, { allowDots: true, encodeDotInKeys: true }),
-            'a%252Eb%252Ec%5B0%5D=1&a%252Eb%252Ec%5B1%5D=2',
-            'array value under nested dotted key (#564: should become a.b%252Ec%5B0%5D=1&a.b%252Ec%5B1%5D=2)'
-        );
-
-        st.equal(
-            qs.stringify({ a: { 'b.c': { d: 'e' } } }, { allowDots: false, encodeDotInKeys: true }),
-            'a%5Bb%252Ec%5D%5Bd%5D=e',
-            'allowDots:false object value encodes the nested-key dot, unlike the primitive-value case (#564: should become a%5Bb.c%5D%5Bd%5D=e)'
+            qs.stringify(
+                { a: { b: { c: { d: 'e' } } } },
+                { allowDots: true, encodeDotInKeys: true }
+            ),
+            'a.b.c.d=e',
+            'every nesting separator is preserved, not just the last one'
         );
 
         st.deepEqual(
@@ -267,8 +235,75 @@ test('stringify()', function (t) {
                 qs.stringify({ a: { b: { c: 'd' } } }, { allowDots: true, encodeDotInKeys: true }),
                 { allowDots: true, decodeDotInKeys: true }
             ),
-            { 'a.b': { c: 'd' } },
-            'the over-encoding breaks the round-trip: {a:{b:{c}}} comes back as {"a.b":{c}} (#564 restores it)'
+            { a: { b: { c: 'd' } } },
+            'stringify -> parse round-trips a deeply nested object'
+        );
+
+        st.end();
+    });
+
+    t.test('encodeDotInKeys encodes only literal dots inside nested keys, never the structural separators, at any depth', function (st) {
+        st.equal(
+            qs.stringify({ a: { 'b.c': { d: 'e' } } }, { allowDots: true, encodeDotInKeys: true }),
+            'a.b%252Ec.d=e',
+            'a nested key with a literal dot and an object value encodes only its own dot'
+        );
+        st.equal(
+            qs.stringify({ 'a.b': { c: { d: 'e' } } }, { allowDots: true, encodeDotInKeys: true }),
+            'a%252Eb.c.d=e',
+            'a top-level dotted key stays encoded while deeper separators stay literal'
+        );
+        st.equal(
+            qs.stringify({ a: { b: { 'c.d': { e: 'f' } } } }, { allowDots: true, encodeDotInKeys: true }),
+            'a.b.c%252Ed.e=f',
+            'a literal dot in a deeply nested key is encoded without touching the separators around it'
+        );
+
+        // arrays nested under keys: the separator before the array indices must stay literal
+        st.equal(
+            qs.stringify({ a: { b: [1, 2] } }, { allowDots: true, encodeDotInKeys: true }),
+            'a.b%5B0%5D=1&a.b%5B1%5D=2',
+            'separator dots are preserved for an array value nested under keys'
+        );
+        st.equal(
+            qs.stringify({ a: { 'b.c': [1, 2] } }, { allowDots: true, encodeDotInKeys: true }),
+            'a.b%252Ec%5B0%5D=1&a.b%252Ec%5B1%5D=2',
+            'a nested dotted key with an array value encodes only its own dot'
+        );
+
+        st.deepEqual(
+            qs.parse(
+                qs.stringify({ a: { 'b.c': { d: 'e' } } }, { allowDots: true, encodeDotInKeys: true }),
+                { allowDots: true, decodeDotInKeys: true }
+            ),
+            { a: { 'b.c': { d: 'e' } } },
+            'stringify -> parse round-trips a nested dotted key with an object value'
+        );
+        st.deepEqual(
+            qs.parse(
+                qs.stringify({ 'a.b': { c: { d: 'e' } } }, { allowDots: true, encodeDotInKeys: true }),
+                { allowDots: true, decodeDotInKeys: true }
+            ),
+            { 'a.b': { c: { d: 'e' } } },
+            'stringify -> parse round-trips a top-level dotted key with deep nesting'
+        );
+
+        st.end();
+    });
+
+    t.test('with allowDots false, encodeDotInKeys leaves nested-key dots literal, consistently for object and primitive values', function (st) {
+        // With allowDots explicitly false, nested keys use bracket notation and their literal
+        // dots are left as-is. Previously an object value re-encoded the dot (via the accumulated
+        // prefix) while a primitive value did not; the two now agree.
+        st.equal(
+            qs.stringify({ a: { 'b.c': { d: 'e' } } }, { allowDots: false, encodeDotInKeys: true }),
+            'a%5Bb.c%5D%5Bd%5D=e',
+            'nested dotted key with an object value'
+        );
+        st.equal(
+            qs.stringify({ a: { 'b.c': 'e' } }, { allowDots: false, encodeDotInKeys: true }),
+            'a%5Bb.c%5D=e',
+            'nested dotted key with a primitive value matches the object-value case'
         );
 
         st.end();


### PR DESCRIPTION
With `allowDots` + `encodeDotInKeys`, `stringify` percent-encodes the structural nesting-separator dots, not just the literal dots inside a key. That breaks the documented `stringify` -> `parse` round-trip for any nested object whose keys do not contain a literal dot.

## Repro

```js
qs.stringify({ a: { b: { c: 'd' } } }, { allowDots: true, encodeDotInKeys: true });
// got:      'a%252Eb.c=d'   (the a->b separator is encoded, the b->c one is not)
// expected: 'a.b.c=d'       (no key has a literal dot, so encodeDotInKeys is a no-op)

qs.parse('a%252Eb.c=d', { allowDots: true, decodeDotInKeys: true });
// got:      { 'a.b': { c: 'd' } }
// expected: { a: { b: { c: 'd' } } }
```

Deeper nesting clobbers every separator except the last:

```js
qs.stringify({ a: { b: { c: { d: 'e' } } } }, { allowDots: true, encodeDotInKeys: true });
// got: 'a%252Eb%252Ec.d=e'   expected: 'a.b.c.d=e'
```

The control case (`{ allowDots: true }` alone) round-trips correctly, so the regression is specific to `encodeDotInKeys`.

## What the option means

Per the README, `encodeDotInKeys` encodes the dots that appear *in the keys of an object*:

```js
qs.stringify({ "name.obj": { "first": "John", "last": "Doe" } }, { allowDots: true, encodeDotInKeys: true })
// 'name%252Eobj.first=John&name%252Eobj.last=Doe'
```

The dot in `name.obj` is part of the key and must be encoded; the dot before `first`/`last` is the separator `allowDots` inserts and must stay literal. The bug encodes both.

## Root cause

`lib/stringify.js`:

```js
var encodedPrefix = encodeDotInKeys ? String(prefix).replace(/\./g, '%2E') : String(prefix);
```

`prefix` is the accumulated key path, so this replace runs again at every level of recursion and re-encodes separator dots that were inherited from parent levels. The literal dots inside an individual key are already handled per segment a few lines down (`encodedKey = ... String(key).replace(...)`), so the prefix-wide replace is the source of the over-encoding.

## Fix

Encode the dots once per key segment in the top-level driver (the same place and the same way nested child keys are already encoded), and let `encodedPrefix` be the plain accumulated path. Two lines in `lib/stringify.js`.

## Relationship to #562

This is a different defect from the open #562, which fixes the *opposite* failure: a top-level key that *contains* a literal dot and has a *primitive* value was *under*-encoded (`{ 'a.b': 'c' }` produced `a.b=c` instead of `a%252Eb=c`). #562 never touches the `encodedPrefix` line, so applying it leaves this over-encoding bug present:

```text
# with only #562's lib change applied to current HEAD:
qs.stringify({ a: { b: { c: 'd' } } }, { allowDots: true, encodeDotInKeys: true })
// still 'a%252Eb.c=d'   (this bug), while #562's own case 'a%252Eb=c' is fixed
```

The two fixes share one line (moving the per-segment encode into the driver), because removing the prefix-wide replace requires the top-level key's own literal dots to be encoded there instead, otherwise the README `name.obj` example regresses. The distinct defect addressed here is the prefix-wide re-encoding on the recursion path.

## Verification

- Added a `stringify` test for the nested separators plus a round-trip assertion; it fails on current HEAD (red) and passes with the fix (green).
- Full suite green: `1016` assertions pass.
- `npm run readme` passes, so every documented `encodeDotInKeys` example still produces its documented output (the `name.obj` literal-dot cases are unchanged).
- `npm run lint` clean (no new warnings on the changed lines).
