### PR TITLE
[Fix] `utils`: encode `+` as `%2B` in iso-8859-1 mode so values round-trip

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -230,9 +230,11 @@ var encode = function encode(str, defaultEncoder, charset, kind, format) {
     }
 
     if (charset === 'iso-8859-1') {
+        // `escape` leaves `+` untouched, but a literal `+` is decoded back to a space,
+        // so it must be percent-encoded to round-trip (the utf-8 path already does this).
         return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
             return '%26%23' + parseInt($0.slice(2), 16) + '%3B';
-        });
+        }).replace(/\+/g, '%2B');
     }
 
     var out = '';

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1298,6 +1298,17 @@ test('stringify()', function (t) {
         st.end();
     });
 
+    t.test('encodes a literal `+` as `%2B` in iso-8859-1 mode so it round-trips', function (st) {
+        st.equal(qs.stringify({ a: 'b+c' }, { charset: 'iso-8859-1' }), 'a=b%2Bc', 'a `+` in a value is percent-encoded');
+        st.equal(qs.stringify({ 'a+b': 'c' }, { charset: 'iso-8859-1' }), 'a%2Bb=c', 'a `+` in a key is percent-encoded');
+        st.deepEqual(
+            qs.parse(qs.stringify({ a: 'b+c' }, { charset: 'iso-8859-1' }), { charset: 'iso-8859-1' }),
+            { a: 'b+c' },
+            'the `+` survives a round-trip instead of decoding to a space'
+        );
+        st.end();
+    });
+
     t.test('respects an explicit charset of utf-8 (the default)', function (st) {
         st.equal(qs.stringify({ a: 'æ' }, { charset: 'utf-8' }), 'a=%C3%A6');
         st.end();


### PR DESCRIPTION
With `charset: 'iso-8859-1'`, a literal `+` in a key or value is emitted unencoded, so it round-trips back as a space:

```js
qs.stringify({ a: 'b+c' }, { charset: 'iso-8859-1' });
// 'a=b+c'
qs.parse('a=b+c', { charset: 'iso-8859-1' });
// { a: 'b c' }  — the + became a space
```

The iso-8859-1 path encodes via `escape`, which leaves `+` untouched, but a `+` in a query string decodes to a space, so the value is silently corrupted. The utf-8 path already percent-encodes it (`a=b%2Bc`). I encode `+` as `%2B` in the iso-8859-1 branch too, matching utf-8, so values containing a `+` survive a round-trip.
