### PR TITLE
[Fix] `stringify`: throw on a non-primitive value in a comma-separated array (#378)

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -116,10 +116,10 @@ var stringify = function stringify(
         obj = serializeDate(obj);
     } else if (generateArrayPrefix === 'comma' && isArray(obj)) {
         obj = utils.maybeMap(obj, function (value) {
-            if (value instanceof Date) {
-                return serializeDate(value);
+            if (Object(value) === value && !(value instanceof Date)) {
+                throw new TypeError('The `comma` array format does not support serializing non-primitive values (e.g. objects or arrays)');
             }
-            return value;
+            return value instanceof Date ? serializeDate(value) : value;
         });
     }
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -681,11 +681,12 @@ test('stringify()', function (t) {
             'a[][b]=1&a[]=2&a[]=3',
             'brackets => brackets'
         );
-        st.equal(
-            qs.stringify({ a: [{ b: 1 }, 2, 3] }, { encodeValuesOnly: true, arrayFormat: 'comma' }),
-            '???',
-            'brackets => brackets',
-            { skip: 'TODO: figure out what this should do' }
+        st['throws'](
+            function () {
+                qs.stringify({ a: [{ b: 1 }, 2, 3] }, { encodeValuesOnly: true, arrayFormat: 'comma' });
+            },
+            TypeError,
+            'comma with a non-primitive array element throws'
         );
         st.equal(
             qs.stringify({ a: [{ b: 1 }, 2, 3] }, { encodeValuesOnly: true }),
@@ -860,6 +861,31 @@ test('stringify()', function (t) {
             qs.stringify({ a: [null] }, { arrayFormat: 'comma', encodeValuesOnly: true, skipNulls: true }),
             '',
             'skipNulls drops a single-null array entirely'
+        );
+
+        st.end();
+    });
+
+    t.test('throws for non-primitive values in arrayFormat=comma (#378)', function (st) {
+        st['throws'](
+            function () { qs.stringify({ a: { b: [{ c: 'd', e: 'f' }] } }, { encode: false, arrayFormat: 'comma' }); },
+            TypeError,
+            'nested object in a comma array throws instead of stringifying to [object Object]'
+        );
+        st['throws'](
+            function () { qs.stringify({ a: [{ b: 1 }] }, { arrayFormat: 'comma', commaRoundTrip: true }); },
+            TypeError,
+            'the commaRoundTrip path also throws'
+        );
+        st['throws'](
+            function () { qs.stringify({ a: [['b', 'c']] }, { encode: false, arrayFormat: 'comma' }); },
+            TypeError,
+            'a nested array element throws'
+        );
+        st.equal(
+            qs.stringify({ a: ['b', 'c', 'd'] }, { arrayFormat: 'comma' }),
+            'a=b%2Cc%2Cd',
+            'primitive elements are unaffected'
         );
 
         st.end();
@@ -1485,11 +1511,12 @@ test('stringify()', function (t) {
         st.equal(qs.stringify(withArray, { encode: false, arrayFormat: 'brackets' }), 'a[b][][c]=d&a[b][][e]=f', 'array, bracket');
         st.equal(qs.stringify(withArray, { encode: false, arrayFormat: 'indices' }), 'a[b][0][c]=d&a[b][0][e]=f', 'array, indices');
         st.equal(qs.stringify(withArray, { encode: false, arrayFormat: 'repeat' }), 'a[b][c]=d&a[b][e]=f', 'array, repeat');
-        st.equal(
-            qs.stringify(withArray, { encode: false, arrayFormat: 'comma' }),
-            '???',
-            'array, comma',
-            { skip: 'TODO: figure out what this should do' }
+        st['throws'](
+            function () {
+                qs.stringify(withArray, { encode: false, arrayFormat: 'comma' });
+            },
+            TypeError,
+            'array, comma: throws on a non-primitive array element'
         );
 
         st.end();


### PR DESCRIPTION
# [Fix] `stringify`: throw on a non-primitive value in a comma-separated array

Fixes #378.

## Problem

`qs.stringify()` with `{ arrayFormat: 'comma' }` silently coerces a non-primitive
array element (a plain object, or a nested array) to the literal string
`'[object Object]'` — or silently flattens a nested array — irrecoverably losing
the nested data:

```js
qs.stringify({ a: { b: [{ c: 'd', e: 'f' }] } }, { encode: false, arrayFormat: 'comma' });
// => 'a[b]=[object Object]'   (the { c, e } object is gone)

qs.stringify({ a: [{ b: 1 }, 2, 3] }, { encodeValuesOnly: true, arrayFormat: 'comma' });
// => 'a=%5Bobject%20Object%5D,2,3'

qs.stringify({ a: [{ b: 1 }] }, { arrayFormat: 'comma', commaRoundTrip: true });
// => 'a%5B%5D=%5Bobject%20Object%5D'   (same bug on the commaRoundTrip path)
```

As the maintainer noted in #378, the current behavior is unusable, and the two
`test/stringify.js` cases that exercise it were left skipped with
`{ skip: 'TODO: figure out what this should do' }`.

## Root cause

In `lib/stringify.js`, when `arrayFormat` is `'comma'` the array is collapsed with
`Array.prototype.join`:

```js
// lib/stringify.js:156
objKeys = [{ value: obj.length > 0 ? obj.join(',') || null : void undefined }];
```

`.join(',')` calls `String()` on every element. For a plain object that yields
`'[object Object]'`; for a nested array it silently flattens. Either way the
structure is lost with no error.

## Fix

Per the maintainer's primary suggestion in #378 ("qs could throw if it encounters a
non-primitive when stringifying arrayFormat comma") using his recommended idiom
(`Object(x) === x`), detect a non-primitive element and throw a descriptive
`TypeError` instead of silently corrupting it.

The check is folded into the pre-existing comma date-serialization map so it runs
before the join, and it is a **net-zero-line** change to the (already 150-line,
at the `max-lines-per-function` limit) `stringify` function:

```js
// lib/stringify.js:117-124
} else if (generateArrayPrefix === 'comma' && isArray(obj)) {
    obj = utils.maybeMap(obj, function (value) {
        if (Object(value) === value && !(value instanceof Date)) {
            throw new TypeError('The `comma` array format does not support serializing non-primitive values (e.g. objects or arrays)');
        }
        return value instanceof Date ? serializeDate(value) : value;
    });
}
```

Preserved behavior (nothing else changes):

- **`Date`** elements are still serialized via `serializeDate` (a `Date` is an
  object, so it is explicitly excluded from the throw). The existing
  `serializeDate` + `comma` tests still pass unchanged.
- **`null` / `undefined`** elements are primitives under `Object(x) === x`
  (`Object(null) !== null`), so they are unaffected — they still join as empty
  values.
- **Primitive** elements (string / number / boolean / symbol / bigint) join
  exactly as before.
- The **`commaRoundTrip`** path is covered by the same guard (it only adjusts the
  key prefix, at `lib/stringify.js:166`, after this point).

## Tests

`test/stringify.js`:

- Converted the two pre-existing skipped `'TODO: figure out what this should do'`
  comma cases into real assertions that now expect a `TypeError`
  (`{ a: [{ b: 1 }, 2, 3] }` and `{ a: { b: [{ c: 'd', e: 'f' }] } }`).
- Added a focused `#378` block asserting the throw for the reported repro, for the
  `commaRoundTrip` path, and for a nested-array element, plus a sanity assertion
  that a primitive comma array is unaffected (`a=b%2Cc%2Cd`).

## Verification

Base commit: `3a890d4ecd3deb72a45d90be36f4f8c5970467c7`

Before (on base):

```
$ node -e "var qs=require('./lib'); console.log(qs.stringify({ a: { b: [{ c: 'd', e: 'f' }] } }, { encode: false, arrayFormat: 'comma' }))"
a[b]=[object Object]
```

After (this change):

```
$ node -e "var qs=require('./lib'); try { qs.stringify({ a: { b: [{ c: 'd', e: 'f' }] } }, { encode: false, arrayFormat: 'comma' }); } catch (e) { console.log(e.constructor.name + ': ' + e.message); }"
TypeError: The `comma` array format does not support serializing non-primitive values (e.g. objects or arrays)

$ node -e "var qs=require('./lib'); console.log(qs.stringify({a:['b','c','d']},{arrayFormat:'comma'})); var d=new Date(6); console.log(qs.stringify({a:[d]},{serializeDate:function(x){return x.getTime();},arrayFormat:'comma'}))"
a=b%2Cc%2Cd
a=6
```

Full suite + lint (equivalent to `npm test` minus the network `posttest` audit):

```
$ npm run tests-only
# tests 1049
# pass  1049
# ok
  (coverage: Statements 100%, Functions 100%, Branches 99.85%)

$ npm run pretest      # evalmd README + eslint . + eclint editorconfig
evalmd info ok
✖ 12 problems (0 errors, 12 warnings)   # all pre-existing no-continue / consistent-return; exit 0
```

## Alternative considered (discussion point)

The maintainer also floated doing "something useful instead" of throwing. The main
alternative is to encode nested structure inside the comma value (some server
schemes do accept `a[b]=…`-style nesting), but there is no single unambiguous
representation of an object inside a `comma` array — which is exactly why these
tests were left as TODOs. Throwing is the safe, explicit, non-lossy default and
matches the maintainer's primary suggestion; a future opt-in could layer a richer
encoding on top without changing this guard.

Minor related note: `Object(x) === x` also treats a `Buffer` array element as a
non-primitive, so `stringify({ a: [buffer] }, { arrayFormat: 'comma' })` now throws
as well (previously it produced `buffer.toString()`). There is no existing test for
that case; if buffers should be exempted they could be excluded alongside `Date`.
