### PR TITLE
docs: clarify 6.14.1 parse bracket behavior change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,8 @@
 
 > [!WARNING]
 > The behaviour of `arrayLimit` has changed and now also applies to `[]` notation. The default arrayLimit is 20.
-> Previously, arrays using `[]` notation were limited by the `parameterLimit` instead. If you rely on the old
-> implicit behaviour, you should set pass `{ arrayLimit: 1000 }` to parse.
+> Previously, arrays using `[]` notation were limited by the `parameterLimit` instead, with a default of 1000. If you
+> rely on the old implicit behaviour, you should set pass `{ arrayLimit: 1000 }` to parse.
 
 ## **6.14.0**
 - [New] `parse`: add `throwOnParameterLimitExceeded` option (#517)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 > [!WARNING]
 > The behaviour of `arrayLimit` has changed and now also applies to `[]` notation. The default arrayLimit is 20.
 > Previously, arrays using `[]` notation were limited by the `parameterLimit` instead, with a default of 1000. If you
-> rely on the old implicit behaviour, you should set pass `{ arrayLimit: 1000 }` to parse.
+> rely on the old implicit behaviour, you should pass `{ arrayLimit: 1000 }` to `parse` as the second parameter.
 
 ## **6.14.0**
 - [New] `parse`: add `throwOnParameterLimitExceeded` option (#517)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@
 - [Tests] `stringify`: increase coverage
 - [Dev Deps] update `eslint`, `@ljharb/eslint-config`, `npmignore`, `es-value-fixtures`, `for-each`, `object-inspect`
 
+> [!WARNING]
+> The behaviour of `arrayLimit` has changed and now also applies to `[]` notation. The default arrayLimit is 20.
+> Previously, arrays using `[]` notation were limited by the `parameterLimit` instead. If you rely on the old
+> implicit behaviour, you should set pass `{ arrayLimit: 1000 }` to parse.
+
 ## **6.14.0**
 - [New] `parse`: add `throwOnParameterLimitExceeded` option (#517)
 - [Refactor] `parse`: use `utils.combine` more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - [Fix] `stringify`: use configured `delimiter` after `charsetSentinel` (#555)
 - [Fix] `stringify`: apply `formatter` to encoded key under `strictNullHandling` (#554)
 - [Fix] `stringify`: skip null/undefined filter-array entries instead of crashing in `encoder` (#551)
-- [Fix] `parse`: handle nested bracket groups and add regression tests (#530)
+- [Fix] `parse`: handle nested bracket groups and add regression tests (#530); changes output for some unbalanced bracket keys (see #558)
 - [readme] fix grammar (#550)
 - [Dev Deps] update `@ljharb/eslint-config`
 - [Tests] add regression tests for keys containing percent-encoded bracket text

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ assert.deepEqual(withIndexedEmptyString, { a: ['b', '', 'c'] });
 Any array members with an index of `20` or greater will instead be converted to an object with the index as the key.
 This is needed to handle cases when someone sent, for example, `a[999999999]` and it will take significant time to iterate over this huge array.
 
+Since v6.14.1, the arrayLimit now applies to ararys specified using both the `[]` and `[0]` syntaxes.
+
 ```javascript
 var withMaxIndex = qs.parse('a[100]=b');
 assert.deepEqual(withMaxIndex, { a: { '100': 'b' } });

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ assert.deepEqual(withIndexedEmptyString, { a: ['b', '', 'c'] });
 Any array members with an index of `20` or greater will instead be converted to an object with the index as the key.
 This is needed to handle cases when someone sent, for example, `a[999999999]` and it will take significant time to iterate over this huge array.
 
-Since v6.14.1, the arrayLimit now applies to ararys specified using both the `[]` and `[0]` syntaxes.
+Since v6.14.1, the arrayLimit now applies to arrays specified using both the `[]` and `[0]` syntaxes.
 
 ```javascript
 var withMaxIndex = qs.parse('a[100]=b');

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ assert.deepEqual(qs.parse('foo[bar][baz]=foobarbaz'), {
 });
 ```
 
+Since v6.14.1 and v6.15.2, `parse` interprets nested bracket groups more consistently. Query strings with unbalanced `[`/`]` can produce different results than in 6.15.1; see [#558](https://github.com/ljharb/qs/issues/558).
+
 By default, when nesting objects **qs** will only parse up to 5 children deep.
 This means if you attempt to parse a string like `'a[b][c][d][e][f][g][h][i]=j'` your resulting object will be:
 
@@ -292,6 +294,8 @@ assert.deepEqual(withIndexedEmptyString, { a: ['b', '', 'c'] });
 **qs** will also limit arrays to a maximum of `20` elements.
 Any array members with an index of `20` or greater will instead be converted to an object with the index as the key.
 This is needed to handle cases when someone sent, for example, `a[999999999]` and it will take significant time to iterate over this huge array.
+
+Since v6.14.1 and v6.15.2, the arrayLimit now applies to arrays specified using both the `[]` and `[0]` syntaxes.
 
 ```javascript
 var withMaxIndex = qs.parse('a[100]=b');


### PR DESCRIPTION
## Summary

- Clarify changelog entry for version 6.14.1 regarding the behavior change of `arrayLimit` and its application to `[]` notation.
- Clarify in README.md that arrayLimit applies to both '[]' and '[0]' syntaxes since v6.14.1.

Fixes #537

## Test plan

- [x] Documentation-only change (no runtime code).
- [ ] Maintainer review for wording and placement.