### PR TITLE
[Fix] stringify: serialize Date values when filter function is used (fixes #475)

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -112,7 +112,9 @@ var stringify = function stringify(
 
     if (typeof filter === 'function') {
         obj = filter(prefix, obj);
-    } else if (obj instanceof Date) {
+    }
+
+    if (obj instanceof Date) {
         obj = serializeDate(obj);
     } else if (generateArrayPrefix === 'comma' && isArray(obj)) {
         obj = utils.maybeMap(obj, function (value) {


### PR DESCRIPTION
﻿When a \ilter\ function is provided to \qs.stringify\, Date values are silently dropped from the output even when the filter returns the Date unchanged (e.g. identity filter or filter that only modifies non-Date values).

**Root cause:** The filter application and Date serialization were in an \if...else if\ chain, so when a filter was present, the \obj instanceof Date\ check was never reached. This caused the stringify function to fall through to the \Object.keys(obj)\ path, which returns \[]\ for Date objects.

**Fix:** Split the \if...else if\ chain so Date serialization runs after filter processing. If the filter returns a Date (or doesn't modify it), it is now properly serialized via \serializeDate\.

Fixes #475
