### PR TITLE
[Fix] utils: don't encode \$ per RFC 3986 (fixes #163)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -250,7 +250,8 @@ var encode = function encode(str, defaultEncoder, charset, kind, format) {
         for (var i = 0; i < segment.length; ++i) {
             var c = segment.charCodeAt(i);
             if (
-                c === 0x2D // -
+                c === 0x24 // $
+                || c === 0x2D // -
                 || c === 0x2E // .
                 || c === 0x5F // _
                 || c === 0x7E // ~

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -905,7 +905,7 @@ test('stringify()', function (t) {
     });
 
     t.test('stringifies the weird object from qs', function (st) {
-        st.equal(qs.stringify({ 'my weird field': '~q1!2"\'w$5&7/z8)?' }), 'my%20weird%20field=~q1%212%22%27w%245%267%2Fz8%29%3F');
+        st.equal(qs.stringify({ 'my weird field': '~q1!2"\'w$5&7/z8)?' }), 'my%20weird%20field=~q1%212%22%27w$5%267%2Fz8%29%3F');
         st.end();
     });
 


### PR DESCRIPTION
﻿Per RFC 3986, \U+0024 DOLLAR SIGN ($)\ is a sub-delimiter character that does not require percent-encoding in query strings. However, qs was encoding it as \%24\.

This change adds \$\ (0x24) to the set of unencoded characters in the \encode\ function, aligning with RFC 3986.

Fixes #163
