### PR TITLE
[Fix] `parse`: flatten a collection appended to an overflowed array

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -338,8 +338,15 @@ var combine = function combine(a, b, arrayLimit, plainObjects, throwOnLimitExcee
         if (throwOnLimitExceeded) {
             throw new RangeError('Array limit exceeded. Only ' + arrayLimit + ' element' + (arrayLimit === 1 ? '' : 's') + ' allowed in an array.');
         }
-        var newIndex = getMaxIndex(a) + 1;
-        a[newIndex] = b;
+        // spread `b` one level, matching the `[].concat(a, b)` used below, so a
+        // collection appended to an already-overflowed object is flattened
+        // rather than nested under a single index
+        var bValues = isArray(b) ? b : [b];
+        var newIndex = getMaxIndex(a);
+        for (var i = 0; i < bValues.length; ++i) {
+            newIndex += 1;
+            a[newIndex] = bValues[i];
+        }
         setMaxIndex(a, newIndex);
         return a;
     }

--- a/test/parse.js
+++ b/test/parse.js
@@ -1475,6 +1475,16 @@ test('parse()', function (t) {
             sst.end();
         });
 
+        st.test('spreads a comma group appended to an already-overflowed object', function (sst) {
+            var result = qs.parse('a=1,2,3,4,5,6&a=7,8', { comma: true, arrayLimit: 5 });
+            sst.deepEqual(
+                result,
+                { a: { 0: '1', 1: '2', 2: '3', 3: '4', 4: '5', 5: '6', 6: '7', 7: '8' } },
+                'appended comma values are flattened, not nested'
+            );
+            sst.end();
+        });
+
         st.test('does not throw for comma groups nested under bracket notation, counting each group as one element', function (sst) {
             var result = qs.parse('a[]=1,2,3&a[]=4,5,6', { comma: true, arrayLimit: 5, throwOnLimitExceeded: true });
             sst.deepEqual(result, { a: [['1', '2', '3'], ['4', '5', '6']] }, 'nested comma groups count as one element each');

--- a/test/parse.js
+++ b/test/parse.js
@@ -1475,6 +1475,73 @@ test('parse()', function (t) {
             sst.end();
         });
 
+        st.test('spreads a comma group appended to an already-overflowed object', function (sst) {
+            var result = qs.parse('a=1,2,3,4,5,6&a=7,8', { comma: true, arrayLimit: 5 });
+            sst.deepEqual(
+                result,
+                { a: { 0: '1', 1: '2', 2: '3', 3: '4', 4: '5', 5: '6', 6: '7', 7: '8' } },
+                'appended comma values are flattened, not nested'
+            );
+            sst.end();
+        });
+
+        st.test('keeps a `[]=` comma group as one element when appended to an already-overflowed key', function (sst) {
+            var result = qs.parse('a[]=1&a[]=2&a[]=3&a[]=4,5', { comma: true, arrayLimit: 2 });
+            sst.deepEqual(
+                result,
+                { a: { 0: '1', 1: '2', 2: '3', 3: ['4', '5'] } },
+                'nested comma group stays a single element, not double-nested'
+            );
+            sst.end();
+        });
+
+        st.test('spreads every later comma group appended to an already-overflowed object', function (sst) {
+            var result = qs.parse('a=1,2,3,4,5,6&a=7,8&a=9,10', { comma: true, arrayLimit: 5 });
+            sst.deepEqual(
+                result,
+                { a: { 0: '1', 1: '2', 2: '3', 3: '4', 4: '5', 5: '6', 6: '7', 7: '8', 8: '9', 9: '10' } },
+                'each appended group is flattened in order'
+            );
+            sst.end();
+        });
+
+        st.test('spreads a comma group appended to an object overflowed under the default arrayLimit', function (sst) {
+            var values = [];
+            for (var i = 0; i <= 20; i += 1) {
+                values[values.length] = String(i);
+            }
+            var expected = {};
+            for (var j = 0; j < values.length; j += 1) {
+                expected[j] = values[j];
+            }
+            expected[21] = 'x';
+            expected[22] = 'y';
+
+            var result = qs.parse('a=' + values.join(',') + '&a=x,y', { comma: true });
+            sst.deepEqual(result, { a: expected }, 'appended values land at indices 21 and 22');
+            sst.end();
+        });
+
+        st.test('spreads a comma group appended to an already-overflowed object with plainObjects', function (sst) {
+            var result = qs.parse('a=1,2,3,4,5,6&a=7,8', { comma: true, arrayLimit: 5, plainObjects: true });
+            sst.deepEqual(
+                result,
+                { __proto__: null, a: { __proto__: null, 0: '1', 1: '2', 2: '3', 3: '4', 4: '5', 5: '6', 6: '7', 7: '8' } },
+                'appended comma values are flattened into the null object'
+            );
+            sst.end();
+        });
+
+        st.test('still throws with throwOnLimitExceeded when a comma group is appended to an already-overflowed object', function (sst) {
+            sst['throws'](
+                function () {
+                    qs.parse('a=1,2,3,4,5,6&a=7,8', { comma: true, arrayLimit: 5, throwOnLimitExceeded: true });
+                },
+                /Array limit exceeded/,
+                'throws before spreading the appended group'
+            );
+            sst.end();
+        });
         st.test('does not throw for comma groups nested under bracket notation, counting each group as one element', function (sst) {
             var result = qs.parse('a[]=1,2,3&a[]=4,5,6', { comma: true, arrayLimit: 5, throwOnLimitExceeded: true });
             sst.deepEqual(result, { a: [['1', '2', '3'], ['4', '5', '6']] }, 'nested comma groups count as one element each');


### PR DESCRIPTION
## What

When a `comma`-split key overflows `arrayLimit` and a later duplicate of the same key adds more values, the extra values are nested under a single index instead of being appended:

```js
qs.parse('a=1,2,3,4,5,6&a=7,8', { comma: true, arrayLimit: 5 })
// actual:   { a: { 0:'1', 1:'2', 2:'3', 3:'4', 4:'5', 5:'6', 6: ['7','8'] } }
// expected: { a: { 0:'1', 1:'2', 2:'3', 3:'4', 4:'5', 5:'6', 6:'7', 7:'8' } }
```

The first comma group (`1,2,3,4,5,6`, 6 elements) exceeds `arrayLimit: 5`, so `a` becomes an overflow object. When the second group (`7,8`) is combined in, `combine`'s overflow branch does `a[newIndex] = b`, assigning the whole `['7','8']` array to index `6`. The non-overflow branch just below spreads via `[].concat(a, b)`; the overflow branch was written assuming `b` is always scalar. It also reproduces with the default `arrayLimit: 20`.

## Fix

Spread `b` one level in the overflow branch, matching the `[].concat(a, b)` semantics of the non-overflow path, so appended values land at successive indices.

## Tests

Added a `parse` case asserting `a=1,2,3,4,5,6&a=7,8` flattens to `{0…7}` (it nests on `main`). Full suite green — `1046/1046`.
