### PR TITLE
[Fix] stringify: respect arrayFormat when using allowEmptyArrays option (fixes #525)

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -68,6 +68,7 @@ var stringify = function stringify(
     prefix,
     generateArrayPrefix,
     commaRoundTrip,
+    arrayFormat,
     allowEmptyArrays,
     strictNullHandling,
     skipNulls,
@@ -166,6 +167,9 @@ var stringify = function stringify(
     var adjustedPrefix = commaRoundTrip && isArray(obj) && obj.length === 1 ? encodedPrefix + '[]' : encodedPrefix;
 
     if (allowEmptyArrays && isArray(obj) && obj.length === 0 && Object.keys(obj).length === 0) {
+        if (arrayFormat === 'repeat' || arrayFormat === 'comma') {
+            return adjustedPrefix;
+        }
         return adjustedPrefix + '[]';
     }
 
@@ -192,6 +196,7 @@ var stringify = function stringify(
             keyPrefix,
             generateArrayPrefix,
             commaRoundTrip,
+            arrayFormat,
             allowEmptyArrays,
             strictNullHandling,
             skipNulls,
@@ -342,6 +347,7 @@ module.exports = function (object, opts) {
             encodedKey,
             generateArrayPrefix,
             commaRoundTrip,
+            options.arrayFormat,
             options.allowEmptyArrays,
             options.strictNullHandling,
             options.skipNulls,


### PR DESCRIPTION
When \llowEmptyArrays: true\ is used, the resulting string always appended \[]\ to the key regardless of the \rrayFormat\ setting. This was inconsistent — for \epeat\ and \comma\ formats, no brackets should be used.

**Changes:**
- Added \rrayFormat\ parameter to the internal \stringify\ function to propagate the format name.
- When \llowEmptyArrays\ fast path fires, check the format:
  - \rackets\ / \indices\: \prefix[]\ (existing behavior, unchanged)
  - \epeat\: just \prefix\ (no brackets)
  - \comma\: just \prefix\ (no brackets)

**Before:**
\\\
qs.stringify({a: []}, { allowEmptyArrays: true, arrayFormat: 'repeat' })
// → 'a[]'  (wrong, should be 'a')
qs.stringify({a: []}, { allowEmptyArrays: true, arrayFormat: 'comma' })
// → 'a[]'  (wrong, should be 'a')
\\\

**After:**
\\\
qs.stringify({a: []}, { allowEmptyArrays: true, arrayFormat: 'repeat' })
// → 'a'
qs.stringify({a: []}, { allowEmptyArrays: true, arrayFormat: 'comma' })
// → 'a'
\\\

Fixes #525